### PR TITLE
fix: a11y modal backdrop role + reactive theme in web app

### DIFF
--- a/crates/keychainpgp-ui/frontend/src/components/modals/ModalContainer.svelte
+++ b/crates/keychainpgp-ui/frontend/src/components/modals/ModalContainer.svelte
@@ -19,9 +19,11 @@
 
 <svelte:window onkeydown={onKeydown} />
 
-<!-- svelte-ignore a11y_click_events_have_key_events a11y_no_static_element_interactions -->
+<!-- svelte-ignore a11y_click_events_have_key_events -->
 <div
   class="fixed inset-0 z-50 flex items-center justify-center bg-black/50"
+  role="button"
+  tabindex="-1"
   onclick={onBackdropClick}
 >
   <div

--- a/web/src/App.svelte
+++ b/web/src/App.svelte
@@ -16,7 +16,9 @@
   let theme: ThemeMode = $state(getTheme());
   let showOnboarding = $state(!hasCompletedOnboarding());
 
-  applyTheme(theme);
+  $effect(() => {
+    applyTheme(theme);
+  });
 
   function toggleTheme() {
     theme = theme === "dark" ? "light" : "dark";


### PR DESCRIPTION
## Summary
- Add `role="button"` and `tabindex="-1"` to modal backdrop div (fixes Svelte a11y warning)
- Wrap `applyTheme(theme)` in `$effect()` so theme changes are reactive in the web app

## Test plan
- [x] No more Svelte a11y warnings
- [x] Theme toggle works reactively