### PR TITLE
feat(i18n): add translation sync script with English fallback

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -45,6 +45,15 @@ New crate dependencies require justification in the PR description:
 - Is the crate well-maintained and audited?
 - Does its license comply with MIT/Apache-2.0?
 
+## Internationalization (i18n)
+
+The frontend supports 20 locales via [Paraglide](https://inlang.com/m/gerre34r/library-inlang-paraglideJs). When adding new UI strings:
+
+- **Only add your keys to `messages/en.json`** — you don't need to touch the other 19 locale files.
+- A pre-build script (`scripts/sync-translations.js`) automatically copies missing keys from `en.json` into all other locales as fallback.
+- Proper translations are handled separately by maintainers after merge.
+- Use the `m.your_key()` pattern in Svelte components (see existing code for examples).
+
 ## Security
 
 - No `unsafe` blocks without a `// SAFETY:` comment and second reviewer approval

--- a/crates/keychainpgp-ui/frontend/messages/ar.json
+++ b/crates/keychainpgp-ui/frontend/messages/ar.json
@@ -1,57 +1,46 @@
 {
   "$schema": "https://inlang.com/schema/inlang-message-format",
-
   "loading": "جارٍ التحميل...",
   "ready": "جاهز",
-
   "nav_home": "تشفير / فك تشفير",
   "nav_keys": "المفاتيح",
   "nav_settings": "الإعدادات",
-
   "home_title": "KeychainPGP",
   "home_tagline_clipboard": "انسخ نصًا، ثم اختر إجراءً أدناه.",
   "home_tagline_compose": "اكتب رسالتك، ثم اختر إجراءً أدناه.",
   "mode_clipboard": "الحافظة",
   "mode_compose": "كتابة",
-
   "action_encrypt": "تشفير",
   "action_decrypt": "فك التشفير",
   "action_sign": "توقيع",
   "action_verify": "تحقّق",
-
   "clipboard_label": "الحافظة",
   "clipboard_empty": "الحافظة فارغة. انسخ نصًا للبدء.",
   "clipboard_pgp_message": "رسالة PGP",
   "clipboard_signed_message": "رسالة موقّعة",
   "clipboard_refresh": "تحديث الحافظة",
-
   "compose_label": "كتابة",
   "compose_placeholder": "اكتب أو الصق رسالتك هنا...",
   "compose_clear": "مسح",
-
   "encrypt_empty_clipboard": "الحافظة فارغة. انسخ نصًا أولاً.",
   "encrypt_empty_compose": "حقل الكتابة فارغ. اكتب رسالة أولاً.",
   "encrypt_no_keys": "لا توجد مفاتيح متاحة. أنشئ مفتاحًا أو استورده أولاً.",
-
   "decrypt_empty_clipboard": "الحافظة فارغة. انسخ رسالة مشفّرة أولاً.",
   "decrypt_empty_compose": "حقل الكتابة فارغ.",
   "decrypt_no_pgp": "لم يتم اكتشاف رسالة PGP.",
   "decrypt_in_progress": "جارٍ فك التشفير...",
   "decrypt_success": "تم فك التشفير بنجاح.",
   "decrypt_wrong_key_hint": "تأكّد من استيراد المفتاح الخاص الصحيح.",
-
   "sign_empty_clipboard": "الحافظة فارغة. انسخ نصًا أولاً.",
   "sign_empty_compose": "حقل الكتابة فارغ.",
   "sign_no_key": "لا يوجد مفتاح خاص متاح. أنشئ مفتاحًا أو استورده أولاً.",
   "sign_in_progress": "جارٍ التوقيع...",
   "sign_success_compose": "تم توقيع الرسالة.",
-
   "verify_empty_clipboard": "الحافظة فارغة. انسخ رسالة موقّعة أولاً.",
   "verify_empty_compose": "حقل الكتابة فارغ.",
   "verify_in_progress": "جارٍ التحقّق...",
   "verify_success": "تم التحقّق من التوقيع.",
   "verify_failed": "فشل التحقّق.",
-
   "verify_modal_title": "التحقّق من التوقيع",
   "verify_valid_verified": "توقيع صالح — تم التحقّق",
   "verify_valid_verified_desc": "تم توقيع هذه الرسالة بمفتاح تم التحقّق منه.",
@@ -61,7 +50,6 @@
   "verify_signer_label": "المُوقِّع",
   "verify_email_label": "البريد الإلكتروني",
   "verify_fingerprint_label": "البصمة",
-
   "keys_title": "مدير المفاتيح",
   "keys_generate": "إنشاء",
   "keys_import_btn": "استيراد",
@@ -74,7 +62,6 @@
   "keys_section_contacts": "جهات الاتصال",
   "keys_export_success": "تم نسخ المفتاح العام إلى الحافظة.",
   "keys_deleted": "تم حذف المفتاح.",
-
   "key_details_title": "تفاصيل المفتاح",
   "key_details_btn": "التفاصيل",
   "key_export_btn": "تصدير المفتاح العام",
@@ -102,7 +89,6 @@
   "key_details_qr_btn": "رمز QR",
   "key_details_not_found": "لم يتم العثور على المفتاح.",
   "key_trust_update_failed": "فشل تحديث الثقة: {error}",
-
   "keygen_title": "إنشاء زوج مفاتيح جديد",
   "keygen_name_placeholder": "الاسم",
   "keygen_email_placeholder": "البريد الإلكتروني",
@@ -112,7 +98,6 @@
   "keygen_submit": "إنشاء",
   "keygen_loading": "جارٍ الإنشاء...",
   "keygen_success": "تم إنشاء زوج المفاتيح بنجاح!",
-
   "onboarding_title": "مرحبًا بك في KeychainPGP",
   "onboarding_subtitle": "أنشئ زوج المفاتيح الأول للبدء بتشفير الحافظة.",
   "onboarding_name_placeholder": "اسمك",
@@ -123,7 +108,6 @@
   "onboarding_import": "استيراد مفتاح موجود",
   "onboarding_scan_qr": "مسح رمز QR",
   "onboarding_sync": "مزامنة من جهاز آخر",
-
   "recipient_title": "اختيار المستلمين",
   "recipient_search_placeholder": "البحث عن مفاتيح...",
   "recipient_no_keys": "لا توجد مفاتيح متاحة.",
@@ -136,7 +120,6 @@
   "recipient_encrypt_btn_other": "تشفير لـ {count} مستلمين",
   "recipient_encrypting": "جارٍ التشفير...",
   "recipient_encrypt_success": "تم تشفير الرسالة ونسخها إلى الحافظة.",
-
   "import_title": "استيراد مفتاح",
   "import_textarea_placeholder": "الصق مفتاح PGP بتنسيق ASCII-armored أو ملف نسخة احتياطية...",
   "import_or": "أو",
@@ -155,32 +138,26 @@
   "import_backup_success_one": "تم استيراد مفتاح واحد",
   "import_backup_success_other": "تم استيراد {count} مفاتيح",
   "import_backup_skipped": "، {count} موجودة بالفعل في حلقة المفاتيح",
-
   "passphrase_title": "أدخل عبارة المرور",
   "passphrase_desc": "هذا المفتاح محمي بعبارة مرور. أدخلها لفك التشفير.",
   "passphrase_placeholder": "عبارة المرور",
   "passphrase_cancel": "إلغاء",
   "passphrase_submit": "فك التشفير",
-
   "decrypted_title": "الرسالة المفكّكة",
   "decrypted_copy": "نسخ",
   "decrypted_copied": "تم النسخ",
   "decrypted_close": "إغلاق",
-
   "error_title": "خطأ",
   "error_fallback": "حدث خطأ غير متوقع.",
   "error_ok": "حسنًا",
-
   "confirm_default_title": "تأكيد",
   "confirm_default_message": "هل أنت متأكد؟",
   "confirm_cancel": "إلغاء",
   "confirm_delete": "حذف",
-
   "qr_title": "تصدير رمز QR",
   "qr_generating": "جارٍ إنشاء رمز QR...",
   "qr_desc": "امسح رمز QR هذا لاستيراد المفتاح العام.",
   "qr_close": "إغلاق",
-
   "discovery_title": "اكتشاف المفاتيح",
   "discovery_placeholder": "عنوان البريد الإلكتروني أو الاسم...",
   "discovery_search": "بحث",
@@ -190,11 +167,9 @@
   "discovery_import_hint": "لاستيراد مفتاح مكتشف، انسخ مفتاحه العام واستخدم وظيفة الاستيراد في عرض المفاتيح.",
   "discovery_import_fail": "تعذّر استرداد بيانات المفتاح للاستيراد.",
   "discovery_close": "إغلاق",
-
   "trust_unknown": "غير معروف",
   "trust_imported": "مُستورد",
   "trust_verified": "تم التحقّق",
-
   "settings_title": "الإعدادات",
   "settings_appearance": "المظهر",
   "settings_theme_system": "النظام",
@@ -202,13 +177,11 @@
   "settings_theme_dark": "داكن",
   "settings_close_to_tray_label": "إغلاق إلى علبة النظام",
   "settings_close_to_tray_desc": "إبقاء التطبيق في علبة النظام عند إغلاق النافذة",
-
   "settings_clipboard": "الحافظة",
   "settings_auto_clear_label": "مسح الحافظة تلقائيًا",
   "settings_auto_clear_desc": "مسح البيانات الحساسة من الحافظة بعد فك التشفير",
   "settings_auto_clear_delay_label": "مهلة المسح التلقائي",
   "settings_auto_clear_delay_desc": "عدد الثواني قبل مسح الحافظة",
-
   "settings_encryption": "التشفير",
   "settings_encrypt_to_self_label": "التشفير لنفسك",
   "settings_encrypt_to_self_desc": "تضمين مفتاحك دائمًا كمستلم",
@@ -217,22 +190,18 @@
   "settings_self_keys_count_other": "تم اختيار {count} مفاتيح.",
   "settings_include_armor_label": "تضمين ترويسات الدرع",
   "settings_include_armor_desc": "إضافة بيانات الإصدار والتعليق الوصفية إلى مخرجات PGP",
-
   "settings_security": "الأمان",
   "settings_passphrase_cache_label": "مدة تخزين عبارة المرور مؤقتًا",
   "settings_passphrase_cache_desc": "مدة تذكّر عبارات المرور بالثواني (0 = معطّل)",
   "settings_clear_cache": "مسح عبارات المرور المخزّنة مؤقتًا",
   "settings_cache_cleared": "تم مسح ذاكرة عبارات المرور المؤقتة.",
   "settings_cache_clear_failed": "فشل مسح الذاكرة المؤقتة: {error}",
-
   "settings_key_discovery": "اكتشاف المفاتيح",
   "settings_keyserver_label": "عنوان خادم المفاتيح",
   "settings_keyserver_desc": "يُستخدم للبحث عن المفاتيح ورفعها",
-
   "settings_language": "اللغة",
   "settings_language_label": "لغة العرض",
   "settings_language_desc": "اختر لغة الواجهة",
-
   "settings_sync": "مزامنة المفاتيح",
   "settings_sync_desc": "انقل مفاتيحك بين الأجهزة بأمان.",
   "settings_sync_export": "تصدير المفاتيح",
@@ -258,7 +227,6 @@
   "sync_error_no_passphrase": "أدخل عبارة مرور المزامنة الظاهرة على جهاز التصدير.",
   "done": "تم",
   "cancel": "إلغاء",
-
   "settings_opsec": "وضع OPSEC",
   "settings_opsec_desc": "وضع مُحصَّن للبيئات عالية الخطورة. تُخزَّن المفاتيح في الذاكرة العشوائية فقط وتُمسح عند الخروج.",
   "settings_opsec_enable": "تفعيل وضع OPSEC",
@@ -280,9 +248,8 @@
   "settings_proxy_success": "نجح الاتصال!",
   "settings_proxy_failed": "فشل الاتصال: {error}",
   "settings_proxy_custom": "مخصص",
-
-  "settings_about": "KeychainPGP {version} — تشفير PGP عبر الحافظة لسطح المكتب.",
   "settings_about_title": "حول",
+  "settings_about": "KeychainPGP {version} — تشفير PGP عبر الحافظة لسطح المكتب.",
   "settings_portable_badge": "الوضع المحمول",
   "donate_button": "ادعم هذا المشروع",
   "donate_title": "ادعم KeychainPGP",
@@ -294,12 +261,10 @@
   "donate_eth": "Ethereum",
   "donate_xmr": "Monero",
   "donate_thanks": "شكرًا لدعمك!",
-
   "unnamed": "(بدون اسم)",
   "none_value": "(لا شيء)",
   "date_na": "غير متاح",
   "fingerprint_copy": "نسخ البصمة",
-
   "kbd_ctrl": "Ctrl",
   "kbd_shift": "Shift"
 }

--- a/crates/keychainpgp-ui/frontend/messages/de.json
+++ b/crates/keychainpgp-ui/frontend/messages/de.json
@@ -1,57 +1,46 @@
 {
   "$schema": "https://inlang.com/schema/inlang-message-format",
-
   "loading": "Laden...",
   "ready": "Bereit",
-
   "nav_home": "Verschlüsseln / Entschlüsseln",
   "nav_keys": "Schlüssel",
   "nav_settings": "Einstellungen",
-
   "home_title": "KeychainPGP",
   "home_tagline_clipboard": "Text kopieren, dann eine Aktion auswählen.",
   "home_tagline_compose": "Nachricht eingeben, dann eine Aktion auswählen.",
   "mode_clipboard": "Zwischenablage",
   "mode_compose": "Verfassen",
-
   "action_encrypt": "VERSCHLÜSSELN",
   "action_decrypt": "ENTSCHLÜSSELN",
   "action_sign": "SIGNIEREN",
   "action_verify": "VERIFIZIEREN",
-
   "clipboard_label": "Zwischenablage",
   "clipboard_empty": "Die Zwischenablage ist leer. Kopieren Sie Text, um loszulegen.",
   "clipboard_pgp_message": "PGP-Nachricht",
   "clipboard_signed_message": "Signierte Nachricht",
   "clipboard_refresh": "Zwischenablage aktualisieren",
-
   "compose_label": "Verfassen",
   "compose_placeholder": "Nachricht hier eingeben oder einfügen...",
   "compose_clear": "Löschen",
-
   "encrypt_empty_clipboard": "Zwischenablage ist leer. Kopieren Sie zuerst einen Text.",
   "encrypt_empty_compose": "Eingabefeld ist leer. Geben Sie zuerst eine Nachricht ein.",
   "encrypt_no_keys": "Keine Schlüssel verfügbar. Erzeugen oder importieren Sie zuerst einen Schlüssel.",
-
   "decrypt_empty_clipboard": "Zwischenablage ist leer. Kopieren Sie zuerst eine verschlüsselte Nachricht.",
   "decrypt_empty_compose": "Eingabefeld ist leer.",
   "decrypt_no_pgp": "Keine PGP-Nachricht erkannt.",
   "decrypt_in_progress": "Entschlüsseln...",
   "decrypt_success": "Erfolgreich entschlüsselt.",
   "decrypt_wrong_key_hint": "Stellen Sie sicher, dass der richtige private Schlüssel importiert ist.",
-
   "sign_empty_clipboard": "Zwischenablage ist leer. Kopieren Sie zuerst einen Text.",
   "sign_empty_compose": "Eingabefeld ist leer.",
   "sign_no_key": "Kein privater Schlüssel verfügbar. Erzeugen oder importieren Sie zuerst einen.",
   "sign_in_progress": "Signieren...",
   "sign_success_compose": "Nachricht signiert.",
-
   "verify_empty_clipboard": "Zwischenablage ist leer. Kopieren Sie zuerst eine signierte Nachricht.",
   "verify_empty_compose": "Eingabefeld ist leer.",
   "verify_in_progress": "Verifizieren...",
   "verify_success": "Signatur verifiziert.",
   "verify_failed": "Verifizierung fehlgeschlagen.",
-
   "verify_modal_title": "Signaturprüfung",
   "verify_valid_verified": "Gültige Signatur — Verifiziert",
   "verify_valid_verified_desc": "Diese Nachricht wurde mit einem verifizierten Schlüssel signiert.",
@@ -61,7 +50,6 @@
   "verify_signer_label": "Unterzeichner",
   "verify_email_label": "E-Mail",
   "verify_fingerprint_label": "Fingerabdruck",
-
   "keys_title": "Schlüsselverwaltung",
   "keys_generate": "Erzeugen",
   "keys_import_btn": "Importieren",
@@ -74,7 +62,6 @@
   "keys_section_contacts": "Kontakte",
   "keys_export_success": "Öffentlicher Schlüssel in die Zwischenablage kopiert.",
   "keys_deleted": "Schlüssel gelöscht.",
-
   "key_details_title": "Schlüsseldetails",
   "key_details_btn": "Details",
   "key_export_btn": "Öffentlichen Schlüssel exportieren",
@@ -102,7 +89,6 @@
   "key_details_qr_btn": "QR-Code",
   "key_details_not_found": "Schlüssel nicht gefunden.",
   "key_trust_update_failed": "Vertrauen konnte nicht aktualisiert werden: {error}",
-
   "keygen_title": "Neues Schlüsselpaar erzeugen",
   "keygen_name_placeholder": "Name",
   "keygen_email_placeholder": "E-Mail",
@@ -112,7 +98,6 @@
   "keygen_submit": "Erzeugen",
   "keygen_loading": "Wird erzeugt...",
   "keygen_success": "Schlüsselpaar erfolgreich erzeugt!",
-
   "onboarding_title": "Willkommen bei KeychainPGP",
   "onboarding_subtitle": "Erzeugen Sie Ihr erstes Schlüsselpaar, um mit der Zwischenablage-Verschlüsselung zu beginnen.",
   "onboarding_name_placeholder": "Ihr Name",
@@ -123,7 +108,6 @@
   "onboarding_import": "Vorhandenen Schlüssel importieren",
   "onboarding_scan_qr": "QR-Code scannen",
   "onboarding_sync": "Von einem anderen Gerät synchronisieren",
-
   "recipient_title": "Empfänger auswählen",
   "recipient_search_placeholder": "Schlüssel suchen...",
   "recipient_no_keys": "Keine Schlüssel verfügbar.",
@@ -136,7 +120,6 @@
   "recipient_encrypt_btn_other": "Für {count} Empfänger verschlüsseln",
   "recipient_encrypting": "Verschlüsseln...",
   "recipient_encrypt_success": "Nachricht verschlüsselt und in die Zwischenablage kopiert.",
-
   "import_title": "Schlüssel importieren",
   "import_textarea_placeholder": "ASCII-armored PGP-Schlüssel oder Sicherungsdatei einfügen...",
   "import_or": "oder",
@@ -155,32 +138,26 @@
   "import_backup_success_one": "1 Schlüssel importiert",
   "import_backup_success_other": "{count} Schlüssel importiert",
   "import_backup_skipped": ", {count} bereits im Schlüsselbund",
-
   "passphrase_title": "Passphrase eingeben",
   "passphrase_desc": "Dieser Schlüssel ist mit einer Passphrase geschützt. Geben Sie sie zum Entschlüsseln ein.",
   "passphrase_placeholder": "Passphrase",
   "passphrase_cancel": "Abbrechen",
   "passphrase_submit": "Entschlüsseln",
-
   "decrypted_title": "Entschlüsselte Nachricht",
   "decrypted_copy": "Kopieren",
   "decrypted_copied": "Kopiert",
   "decrypted_close": "Schließen",
-
   "error_title": "Fehler",
   "error_fallback": "Ein unerwarteter Fehler ist aufgetreten.",
   "error_ok": "OK",
-
   "confirm_default_title": "Bestätigen",
   "confirm_default_message": "Sind Sie sicher?",
   "confirm_cancel": "Abbrechen",
   "confirm_delete": "Löschen",
-
   "qr_title": "QR-Code-Export",
   "qr_generating": "QR-Code wird erzeugt...",
   "qr_desc": "Scannen Sie diesen QR-Code, um den öffentlichen Schlüssel zu importieren.",
   "qr_close": "Schließen",
-
   "discovery_title": "Schlüssel suchen",
   "discovery_placeholder": "E-Mail-Adresse oder Name...",
   "discovery_search": "Suchen",
@@ -190,11 +167,9 @@
   "discovery_import_hint": "Um einen gefundenen Schlüssel zu importieren, kopieren Sie seinen öffentlichen Schlüssel und verwenden Sie die Importfunktion in der Schlüsselansicht.",
   "discovery_import_fail": "Schlüsseldaten konnten nicht zum Import abgerufen werden.",
   "discovery_close": "Schließen",
-
   "trust_unknown": "Unbekannt",
   "trust_imported": "Importiert",
   "trust_verified": "Verifiziert",
-
   "settings_title": "Einstellungen",
   "settings_appearance": "Darstellung",
   "settings_theme_system": "System",
@@ -202,13 +177,11 @@
   "settings_theme_dark": "Dunkel",
   "settings_close_to_tray_label": "In den Infobereich schließen",
   "settings_close_to_tray_desc": "Die App im Infobereich weiterlaufen lassen, wenn Sie das Fenster schließen",
-
   "settings_clipboard": "Zwischenablage",
   "settings_auto_clear_label": "Zwischenablage automatisch leeren",
   "settings_auto_clear_desc": "Sensible Daten nach dem Entschlüsseln aus der Zwischenablage entfernen",
   "settings_auto_clear_delay_label": "Verzögerung beim automatischen Leeren",
   "settings_auto_clear_delay_desc": "Sekunden, bis die Zwischenablage geleert wird",
-
   "settings_encryption": "Verschlüsselung",
   "settings_encrypt_to_self_label": "An sich selbst verschlüsseln",
   "settings_encrypt_to_self_desc": "Eigenen Schlüssel immer als Empfänger einschließen",
@@ -217,22 +190,18 @@
   "settings_self_keys_count_other": "{count} Schlüssel ausgewählt.",
   "settings_include_armor_label": "Armor-Header einschließen",
   "settings_include_armor_desc": "Versions- und Kommentar-Metadaten zur PGP-Ausgabe hinzufügen",
-
   "settings_security": "Sicherheit",
   "settings_passphrase_cache_label": "Passphrase-Cachedauer",
   "settings_passphrase_cache_desc": "Sekunden, die Passphrasen gespeichert bleiben (0 = deaktiviert)",
   "settings_clear_cache": "Gespeicherte Passphrasen löschen",
   "settings_cache_cleared": "Passphrase-Cache geleert.",
   "settings_cache_clear_failed": "Cache konnte nicht geleert werden: {error}",
-
   "settings_key_discovery": "Schlüsselsuche",
   "settings_keyserver_label": "Schlüsselserver-URL",
   "settings_keyserver_desc": "Wird für die Schlüsselsuche und den Upload verwendet",
-
   "settings_language": "Sprache",
   "settings_language_label": "Anzeigesprache",
   "settings_language_desc": "Sprache der Benutzeroberfläche auswählen",
-
   "settings_sync": "Schlüssel-Synchronisation",
   "settings_sync_desc": "Übertragen Sie Ihre Schlüssel sicher zwischen Geräten.",
   "settings_sync_export": "Schlüssel exportieren",
@@ -258,7 +227,6 @@
   "sync_error_no_passphrase": "Geben Sie die Passphrase ein, die auf dem exportierenden Gerät angezeigt wird.",
   "done": "Fertig",
   "cancel": "Abbrechen",
-
   "settings_opsec": "OPSEC-Modus",
   "settings_opsec_desc": "Gehärteter Modus für Hochrisikoumgebungen. Schlüssel werden nur im RAM gespeichert und beim Beenden gelöscht.",
   "settings_opsec_enable": "OPSEC-Modus aktivieren",
@@ -280,7 +248,6 @@
   "settings_proxy_success": "Verbindung erfolgreich!",
   "settings_proxy_failed": "Verbindung fehlgeschlagen: {error}",
   "settings_proxy_custom": "Benutzerdefiniert",
-
   "settings_about_title": "Über",
   "settings_about": "KeychainPGP {version} — Zwischenablage-basierte PGP-Verschlüsselung für den Desktop.",
   "settings_portable_badge": "Portabler Modus",
@@ -294,12 +261,10 @@
   "donate_eth": "Ethereum",
   "donate_xmr": "Monero",
   "donate_thanks": "Vielen Dank für Ihre Unterstützung!",
-
   "unnamed": "(unbenannt)",
   "none_value": "(keine)",
   "date_na": "k. A.",
   "fingerprint_copy": "Fingerabdruck kopieren",
-
   "kbd_ctrl": "Strg",
   "kbd_shift": "Umschalt"
 }

--- a/crates/keychainpgp-ui/frontend/messages/en.json
+++ b/crates/keychainpgp-ui/frontend/messages/en.json
@@ -1,57 +1,46 @@
 {
   "$schema": "https://inlang.com/schema/inlang-message-format",
-
   "loading": "Loading...",
   "ready": "Ready",
-
   "nav_home": "Encrypt / Decrypt",
   "nav_keys": "Keys",
   "nav_settings": "Settings",
-
   "home_title": "KeychainPGP",
   "home_tagline_clipboard": "Copy text, then choose an action below.",
   "home_tagline_compose": "Type your message, then choose an action below.",
   "mode_clipboard": "Clipboard",
   "mode_compose": "Compose",
-
   "action_encrypt": "ENCRYPT",
   "action_decrypt": "DECRYPT",
   "action_sign": "SIGN",
   "action_verify": "VERIFY",
-
   "clipboard_label": "Clipboard",
   "clipboard_empty": "Your clipboard is empty. Copy some text to get started.",
   "clipboard_pgp_message": "PGP Message",
   "clipboard_signed_message": "Signed Message",
   "clipboard_refresh": "Refresh clipboard",
-
   "compose_label": "Compose",
   "compose_placeholder": "Type or paste your message here...",
   "compose_clear": "Clear",
-
   "encrypt_empty_clipboard": "Clipboard is empty. Copy some text first.",
   "encrypt_empty_compose": "Compose field is empty. Type a message first.",
   "encrypt_no_keys": "No keys available. Generate or import a key first.",
-
   "decrypt_empty_clipboard": "Clipboard is empty. Copy an encrypted message first.",
   "decrypt_empty_compose": "Compose field is empty.",
   "decrypt_no_pgp": "No PGP message detected.",
   "decrypt_in_progress": "Decrypting...",
   "decrypt_success": "Decrypted successfully.",
   "decrypt_wrong_key_hint": "Make sure you have the correct private key imported.",
-
   "sign_empty_clipboard": "Clipboard is empty. Copy some text first.",
   "sign_empty_compose": "Compose field is empty.",
   "sign_no_key": "No private key available. Generate or import one first.",
   "sign_in_progress": "Signing...",
   "sign_success_compose": "Message signed.",
-
   "verify_empty_clipboard": "Clipboard is empty. Copy a signed message first.",
   "verify_empty_compose": "Compose field is empty.",
   "verify_in_progress": "Verifying...",
   "verify_success": "Signature verified.",
   "verify_failed": "Verification failed.",
-
   "verify_modal_title": "Signature Verification",
   "verify_valid_verified": "Valid Signature — Verified",
   "verify_valid_verified_desc": "This message was signed by a verified key.",
@@ -61,7 +50,6 @@
   "verify_signer_label": "Signer",
   "verify_email_label": "Email",
   "verify_fingerprint_label": "Fingerprint",
-
   "keys_title": "Key Manager",
   "keys_generate": "Generate",
   "keys_import_btn": "Import",
@@ -74,7 +62,6 @@
   "keys_section_contacts": "Contacts",
   "keys_export_success": "Public key copied to clipboard.",
   "keys_deleted": "Key deleted.",
-
   "key_details_title": "Key Details",
   "key_details_btn": "Details",
   "key_export_btn": "Export public key",
@@ -102,7 +89,6 @@
   "key_details_qr_btn": "QR Code",
   "key_details_not_found": "Key not found.",
   "key_trust_update_failed": "Failed to update trust: {error}",
-
   "keygen_title": "Generate New Key Pair",
   "keygen_name_placeholder": "Name",
   "keygen_email_placeholder": "Email",
@@ -112,7 +98,6 @@
   "keygen_submit": "Generate",
   "keygen_loading": "Generating...",
   "keygen_success": "Key pair generated successfully!",
-
   "onboarding_title": "Welcome to KeychainPGP",
   "onboarding_subtitle": "Generate your first key pair to get started with clipboard encryption.",
   "onboarding_name_placeholder": "Your name",
@@ -123,7 +108,6 @@
   "onboarding_import": "Import Existing Key",
   "onboarding_scan_qr": "Scan QR Code",
   "onboarding_sync": "Sync from Another Device",
-
   "recipient_title": "Select Recipients",
   "recipient_search_placeholder": "Search keys...",
   "recipient_no_keys": "No keys available.",
@@ -136,7 +120,6 @@
   "recipient_encrypt_btn_other": "Encrypt for {count} recipients",
   "recipient_encrypting": "Encrypting...",
   "recipient_encrypt_success": "Message encrypted and copied to clipboard.",
-
   "import_title": "Import Key",
   "import_textarea_placeholder": "Paste ASCII-armored PGP key or backup file...",
   "import_or": "or",
@@ -155,32 +138,26 @@
   "import_backup_success_one": "Imported 1 key",
   "import_backup_success_other": "Imported {count} keys",
   "import_backup_skipped": ", {count} already in keyring",
-
   "passphrase_title": "Enter Passphrase",
   "passphrase_desc": "This key is protected with a passphrase. Enter it to decrypt.",
   "passphrase_placeholder": "Passphrase",
   "passphrase_cancel": "Cancel",
   "passphrase_submit": "Decrypt",
-
   "decrypted_title": "Decrypted Message",
   "decrypted_copy": "Copy",
   "decrypted_copied": "Copied",
   "decrypted_close": "Close",
-
   "error_title": "Error",
   "error_fallback": "An unexpected error occurred.",
   "error_ok": "OK",
-
   "confirm_default_title": "Confirm",
   "confirm_default_message": "Are you sure?",
   "confirm_cancel": "Cancel",
   "confirm_delete": "Delete",
-
   "qr_title": "QR Code Export",
   "qr_generating": "Generating QR code...",
   "qr_desc": "Scan this QR code to import the public key.",
   "qr_close": "Close",
-
   "discovery_title": "Discover Keys",
   "discovery_placeholder": "Email address or name...",
   "discovery_search": "Search",
@@ -190,11 +167,9 @@
   "discovery_import_hint": "To import a discovered key, copy its public key and use the Import function in the Keys view.",
   "discovery_import_fail": "Could not retrieve key data for import.",
   "discovery_close": "Close",
-
   "trust_unknown": "Unknown",
   "trust_imported": "Imported",
   "trust_verified": "Verified",
-
   "settings_title": "Settings",
   "settings_appearance": "Appearance",
   "settings_theme_system": "System",
@@ -202,13 +177,11 @@
   "settings_theme_dark": "Dark",
   "settings_close_to_tray_label": "Close to tray",
   "settings_close_to_tray_desc": "Keep the app running in the system tray when you close the window",
-
   "settings_clipboard": "Clipboard",
   "settings_auto_clear_label": "Auto-clear clipboard",
   "settings_auto_clear_desc": "Clear sensitive data from clipboard after decryption",
   "settings_auto_clear_delay_label": "Auto-clear delay",
   "settings_auto_clear_delay_desc": "Seconds before clipboard is cleared",
-
   "settings_encryption": "Encryption",
   "settings_encrypt_to_self_label": "Encrypt to self",
   "settings_encrypt_to_self_desc": "Always include your own key as a recipient",
@@ -217,27 +190,22 @@
   "settings_self_keys_count_other": "{count} keys selected.",
   "settings_include_armor_label": "Include armor headers",
   "settings_include_armor_desc": "Add Version and Comment metadata to PGP output",
-
   "settings_security": "Security",
   "settings_passphrase_cache_label": "Passphrase cache duration",
   "settings_passphrase_cache_desc": "Seconds to remember passphrases (0 = disabled)",
   "settings_clear_cache": "Clear cached passphrases",
   "settings_cache_cleared": "Passphrase cache cleared.",
   "settings_cache_clear_failed": "Failed to clear cache: {error}",
-
   "settings_key_discovery": "Key Discovery",
   "settings_keyserver_label": "Keyserver URL",
   "settings_keyserver_desc": "Used for key search and upload",
-
   "settings_language": "Language",
   "settings_language_label": "Display language",
   "settings_language_desc": "Choose the language for the interface",
-
   "settings_sync": "Key Sync",
   "settings_sync_desc": "Transfer your keys between devices securely.",
   "settings_sync_export": "Export Keys",
   "settings_sync_import": "Import Keys",
-
   "sync_export_title": "Export Keys for Sync",
   "sync_import_title": "Import Keys from Device",
   "sync_exporting": "Preparing key bundle...",
@@ -259,7 +227,6 @@
   "sync_error_no_passphrase": "Enter the sync passphrase shown on the exporting device.",
   "done": "Done",
   "cancel": "Cancel",
-
   "settings_opsec": "OPSEC Mode",
   "settings_opsec_desc": "Hardened mode for high-risk environments. Keys are stored in RAM only and wiped on exit.",
   "settings_opsec_enable": "Enable OPSEC Mode",
@@ -271,7 +238,6 @@
   "opsec_closing_in": "Closing in {seconds}s...",
   "opsec_enabled": "OPSEC mode enabled.",
   "opsec_disabled": "OPSEC mode disabled.",
-
   "settings_proxy": "Network Proxy",
   "settings_proxy_desc": "Route keyserver traffic through a SOCKS5 proxy (Tor, Lokinet, etc.).",
   "settings_proxy_enable": "Enable proxy",
@@ -282,11 +248,9 @@
   "settings_proxy_success": "Connection successful!",
   "settings_proxy_failed": "Connection failed: {error}",
   "settings_proxy_custom": "Custom",
-
   "settings_about_title": "About",
   "settings_about": "KeychainPGP {version} — Clipboard-first PGP encryption for desktop.",
   "settings_portable_badge": "Portable Mode",
-
   "donate_button": "Support this project",
   "donate_title": "Support KeychainPGP",
   "donate_desc": "KeychainPGP is free and open source. If you find it useful, consider donating directly — no middlemen, no tracking.",
@@ -297,12 +261,10 @@
   "donate_eth": "Ethereum",
   "donate_xmr": "Monero",
   "donate_thanks": "Thank you for your support!",
-
   "unnamed": "(unnamed)",
   "none_value": "(none)",
   "date_na": "N/A",
   "fingerprint_copy": "Copy fingerprint",
-
   "kbd_ctrl": "Ctrl",
   "kbd_shift": "Shift"
 }

--- a/crates/keychainpgp-ui/frontend/messages/es.json
+++ b/crates/keychainpgp-ui/frontend/messages/es.json
@@ -1,57 +1,46 @@
 {
   "$schema": "https://inlang.com/schema/inlang-message-format",
-
   "loading": "Cargando...",
   "ready": "Listo",
-
   "nav_home": "Cifrar / Descifrar",
   "nav_keys": "Claves",
   "nav_settings": "Ajustes",
-
   "home_title": "KeychainPGP",
   "home_tagline_clipboard": "Copia un texto y elige una acción a continuación.",
   "home_tagline_compose": "Escribe tu mensaje y elige una acción a continuación.",
   "mode_clipboard": "Portapapeles",
   "mode_compose": "Redactar",
-
   "action_encrypt": "CIFRAR",
   "action_decrypt": "DESCIFRAR",
   "action_sign": "FIRMAR",
   "action_verify": "VERIFICAR",
-
   "clipboard_label": "Portapapeles",
   "clipboard_empty": "El portapapeles está vacío. Copia algo de texto para comenzar.",
   "clipboard_pgp_message": "Mensaje PGP",
   "clipboard_signed_message": "Mensaje firmado",
   "clipboard_refresh": "Actualizar portapapeles",
-
   "compose_label": "Redactar",
   "compose_placeholder": "Escribe o pega tu mensaje aquí...",
   "compose_clear": "Borrar",
-
   "encrypt_empty_clipboard": "El portapapeles está vacío. Copia algo de texto primero.",
   "encrypt_empty_compose": "El campo de redacción está vacío. Escribe un mensaje primero.",
   "encrypt_no_keys": "No hay claves disponibles. Genera o importa una clave primero.",
-
   "decrypt_empty_clipboard": "El portapapeles está vacío. Copia un mensaje cifrado primero.",
   "decrypt_empty_compose": "El campo de redacción está vacío.",
   "decrypt_no_pgp": "No se detectó ningún mensaje PGP.",
   "decrypt_in_progress": "Descifrando...",
   "decrypt_success": "Descifrado correctamente.",
   "decrypt_wrong_key_hint": "Asegúrate de tener la clave privada correcta importada.",
-
   "sign_empty_clipboard": "El portapapeles está vacío. Copia algo de texto primero.",
   "sign_empty_compose": "El campo de redacción está vacío.",
   "sign_no_key": "No hay clave privada disponible. Genera o importa una primero.",
   "sign_in_progress": "Firmando...",
   "sign_success_compose": "Mensaje firmado.",
-
   "verify_empty_clipboard": "El portapapeles está vacío. Copia un mensaje firmado primero.",
   "verify_empty_compose": "El campo de redacción está vacío.",
   "verify_in_progress": "Verificando...",
   "verify_success": "Firma verificada.",
   "verify_failed": "La verificación falló.",
-
   "verify_modal_title": "Verificación de firma",
   "verify_valid_verified": "Firma válida — Verificada",
   "verify_valid_verified_desc": "Este mensaje fue firmado por una clave verificada.",
@@ -61,7 +50,6 @@
   "verify_signer_label": "Firmante",
   "verify_email_label": "Correo electrónico",
   "verify_fingerprint_label": "Huella digital",
-
   "keys_title": "Gestor de claves",
   "keys_generate": "Generar",
   "keys_import_btn": "Importar",
@@ -74,7 +62,6 @@
   "keys_section_contacts": "Contactos",
   "keys_export_success": "Clave pública copiada al portapapeles.",
   "keys_deleted": "Clave eliminada.",
-
   "key_details_title": "Detalles de la clave",
   "key_details_btn": "Detalles",
   "key_export_btn": "Exportar clave pública",
@@ -102,7 +89,6 @@
   "key_details_qr_btn": "Código QR",
   "key_details_not_found": "Clave no encontrada.",
   "key_trust_update_failed": "No se pudo actualizar la confianza: {error}",
-
   "keygen_title": "Generar nuevo par de claves",
   "keygen_name_placeholder": "Nombre",
   "keygen_email_placeholder": "Correo electrónico",
@@ -112,7 +98,6 @@
   "keygen_submit": "Generar",
   "keygen_loading": "Generando...",
   "keygen_success": "¡Par de claves generado correctamente!",
-
   "onboarding_title": "Bienvenido a KeychainPGP",
   "onboarding_subtitle": "Genera tu primer par de claves para comenzar a cifrar desde el portapapeles.",
   "onboarding_name_placeholder": "Tu nombre",
@@ -123,7 +108,6 @@
   "onboarding_import": "Importar clave existente",
   "onboarding_scan_qr": "Escanear código QR",
   "onboarding_sync": "Sincronizar desde otro dispositivo",
-
   "recipient_title": "Seleccionar destinatarios",
   "recipient_search_placeholder": "Buscar claves...",
   "recipient_no_keys": "No hay claves disponibles.",
@@ -136,7 +120,6 @@
   "recipient_encrypt_btn_other": "Cifrar para {count} destinatarios",
   "recipient_encrypting": "Cifrando...",
   "recipient_encrypt_success": "Mensaje cifrado y copiado al portapapeles.",
-
   "import_title": "Importar clave",
   "import_textarea_placeholder": "Pega una clave PGP en formato ASCII-armored o un archivo de respaldo...",
   "import_or": "o",
@@ -155,32 +138,26 @@
   "import_backup_success_one": "1 clave importada",
   "import_backup_success_other": "{count} claves importadas",
   "import_backup_skipped": ", {count} ya en el llavero",
-
   "passphrase_title": "Introducir frase de contraseña",
   "passphrase_desc": "Esta clave está protegida con una frase de contraseña. Introdúcela para descifrar.",
   "passphrase_placeholder": "Frase de contraseña",
   "passphrase_cancel": "Cancelar",
   "passphrase_submit": "Descifrar",
-
   "decrypted_title": "Mensaje descifrado",
   "decrypted_copy": "Copiar",
   "decrypted_copied": "Copiado",
   "decrypted_close": "Cerrar",
-
   "error_title": "Error",
   "error_fallback": "Ha ocurrido un error inesperado.",
   "error_ok": "Aceptar",
-
   "confirm_default_title": "Confirmar",
   "confirm_default_message": "¿Estás seguro?",
   "confirm_cancel": "Cancelar",
   "confirm_delete": "Eliminar",
-
   "qr_title": "Exportar código QR",
   "qr_generating": "Generando código QR...",
   "qr_desc": "Escanea este código QR para importar la clave pública.",
   "qr_close": "Cerrar",
-
   "discovery_title": "Buscar claves",
   "discovery_placeholder": "Dirección de correo o nombre...",
   "discovery_search": "Buscar",
@@ -190,11 +167,9 @@
   "discovery_import_hint": "Para importar una clave descubierta, copia su clave pública y usa la función Importar en la vista de Claves.",
   "discovery_import_fail": "No se pudieron obtener los datos de la clave para importar.",
   "discovery_close": "Cerrar",
-
   "trust_unknown": "Desconocida",
   "trust_imported": "Importada",
   "trust_verified": "Verificada",
-
   "settings_title": "Ajustes",
   "settings_appearance": "Apariencia",
   "settings_theme_system": "Sistema",
@@ -202,13 +177,11 @@
   "settings_theme_dark": "Oscuro",
   "settings_close_to_tray_label": "Cerrar a la bandeja",
   "settings_close_to_tray_desc": "Mantener la aplicación en la bandeja del sistema al cerrar la ventana",
-
   "settings_clipboard": "Portapapeles",
   "settings_auto_clear_label": "Vaciar portapapeles automáticamente",
   "settings_auto_clear_desc": "Eliminar datos sensibles del portapapeles después de descifrar",
   "settings_auto_clear_delay_label": "Retraso del vaciado automático",
   "settings_auto_clear_delay_desc": "Segundos antes de vaciar el portapapeles",
-
   "settings_encryption": "Cifrado",
   "settings_encrypt_to_self_label": "Cifrar para uno mismo",
   "settings_encrypt_to_self_desc": "Incluir siempre tu propia clave como destinatario",
@@ -217,22 +190,18 @@
   "settings_self_keys_count_other": "{count} claves seleccionadas.",
   "settings_include_armor_label": "Incluir cabeceras armor",
   "settings_include_armor_desc": "Añadir metadatos de versión y comentario a la salida PGP",
-
   "settings_security": "Seguridad",
   "settings_passphrase_cache_label": "Duración de la caché de frases de contraseña",
   "settings_passphrase_cache_desc": "Segundos que se recuerdan las frases de contraseña (0 = desactivado)",
   "settings_clear_cache": "Borrar frases de contraseña en caché",
   "settings_cache_cleared": "Caché de frases de contraseña borrada.",
   "settings_cache_clear_failed": "No se pudo borrar la caché: {error}",
-
   "settings_key_discovery": "Descubrimiento de claves",
   "settings_keyserver_label": "URL del servidor de claves",
   "settings_keyserver_desc": "Se usa para buscar y subir claves",
-
   "settings_language": "Idioma",
   "settings_language_label": "Idioma de la interfaz",
   "settings_language_desc": "Elige el idioma de la interfaz",
-
   "settings_sync": "Sincronización de claves",
   "settings_sync_desc": "Transfiere tus claves entre dispositivos de forma segura.",
   "settings_sync_export": "Exportar claves",
@@ -258,7 +227,6 @@
   "sync_error_no_passphrase": "Introduce la frase de sincronización que se muestra en el dispositivo exportador.",
   "done": "Hecho",
   "cancel": "Cancelar",
-
   "settings_opsec": "Modo OPSEC",
   "settings_opsec_desc": "Modo reforzado para entornos de alto riesgo. Las claves se almacenan solo en RAM y se borran al salir.",
   "settings_opsec_enable": "Activar modo OPSEC",
@@ -280,7 +248,6 @@
   "settings_proxy_success": "Conexión exitosa!",
   "settings_proxy_failed": "Error de conexión: {error}",
   "settings_proxy_custom": "Personalizado",
-
   "settings_about_title": "Acerca de",
   "settings_about": "KeychainPGP {version} — Cifrado PGP desde el portapapeles para escritorio.",
   "settings_portable_badge": "Modo portátil",
@@ -294,12 +261,10 @@
   "donate_eth": "Ethereum",
   "donate_xmr": "Monero",
   "donate_thanks": "¡Gracias por tu apoyo!",
-
   "unnamed": "(sin nombre)",
   "none_value": "(ninguno)",
   "date_na": "N/D",
   "fingerprint_copy": "Copiar huella digital",
-
   "kbd_ctrl": "Ctrl",
   "kbd_shift": "Mayús"
 }

--- a/crates/keychainpgp-ui/frontend/messages/fr.json
+++ b/crates/keychainpgp-ui/frontend/messages/fr.json
@@ -1,57 +1,46 @@
 {
   "$schema": "https://inlang.com/schema/inlang-message-format",
-
   "loading": "Chargement...",
   "ready": "Prêt",
-
   "nav_home": "Chiffrer / Déchiffrer",
   "nav_keys": "Clés",
   "nav_settings": "Paramètres",
-
   "home_title": "KeychainPGP",
   "home_tagline_clipboard": "Copiez du texte, puis choisissez une action ci-dessous.",
   "home_tagline_compose": "Saisissez votre message, puis choisissez une action ci-dessous.",
   "mode_clipboard": "Presse-papiers",
   "mode_compose": "Rédiger",
-
   "action_encrypt": "CHIFFRER",
   "action_decrypt": "DÉCHIFFRER",
   "action_sign": "SIGNER",
   "action_verify": "VÉRIFIER",
-
   "clipboard_label": "Presse-papiers",
   "clipboard_empty": "Votre presse-papiers est vide. Copiez du texte pour commencer.",
   "clipboard_pgp_message": "Message PGP",
   "clipboard_signed_message": "Message signé",
   "clipboard_refresh": "Actualiser le presse-papiers",
-
   "compose_label": "Rédaction",
   "compose_placeholder": "Saisissez ou collez votre message ici...",
   "compose_clear": "Effacer",
-
   "encrypt_empty_clipboard": "Le presse-papiers est vide. Copiez du texte d'abord.",
   "encrypt_empty_compose": "Le champ de rédaction est vide. Saisissez un message.",
   "encrypt_no_keys": "Aucune clé disponible. Générez ou importez une clé d'abord.",
-
   "decrypt_empty_clipboard": "Le presse-papiers est vide. Copiez un message chiffré d'abord.",
   "decrypt_empty_compose": "Le champ de rédaction est vide.",
   "decrypt_no_pgp": "Aucun message PGP détecté.",
   "decrypt_in_progress": "Déchiffrement...",
   "decrypt_success": "Déchiffré avec succès.",
   "decrypt_wrong_key_hint": "Assurez-vous d'avoir importé la bonne clé privée.",
-
   "sign_empty_clipboard": "Le presse-papiers est vide. Copiez du texte d'abord.",
   "sign_empty_compose": "Le champ de rédaction est vide.",
   "sign_no_key": "Aucune clé privée disponible. Générez ou importez-en une d'abord.",
   "sign_in_progress": "Signature...",
   "sign_success_compose": "Message signé.",
-
   "verify_empty_clipboard": "Le presse-papiers est vide. Copiez un message signé d'abord.",
   "verify_empty_compose": "Le champ de rédaction est vide.",
   "verify_in_progress": "Vérification...",
   "verify_success": "Signature vérifiée.",
   "verify_failed": "Échec de la vérification.",
-
   "verify_modal_title": "Vérification de signature",
   "verify_valid_verified": "Signature valide — Vérifiée",
   "verify_valid_verified_desc": "Ce message a été signé par une clé vérifiée.",
@@ -61,7 +50,6 @@
   "verify_signer_label": "Signataire",
   "verify_email_label": "E-mail",
   "verify_fingerprint_label": "Empreinte",
-
   "keys_title": "Gestionnaire de clés",
   "keys_generate": "Générer",
   "keys_import_btn": "Importer",
@@ -74,7 +62,6 @@
   "keys_section_contacts": "Contacts",
   "keys_export_success": "Clé publique copiée dans le presse-papiers.",
   "keys_deleted": "Clé supprimée.",
-
   "key_details_title": "Détails de la clé",
   "key_details_btn": "Détails",
   "key_export_btn": "Exporter la clé publique",
@@ -102,7 +89,6 @@
   "key_details_qr_btn": "Code QR",
   "key_details_not_found": "Clé introuvable.",
   "key_trust_update_failed": "Impossible de mettre à jour la confiance : {error}",
-
   "keygen_title": "Générer une nouvelle paire de clés",
   "keygen_name_placeholder": "Nom",
   "keygen_email_placeholder": "E-mail",
@@ -112,7 +98,6 @@
   "keygen_submit": "Générer",
   "keygen_loading": "Génération...",
   "keygen_success": "Paire de clés générée avec succès !",
-
   "onboarding_title": "Bienvenue sur KeychainPGP",
   "onboarding_subtitle": "Générez votre première paire de clés pour commencer le chiffrement.",
   "onboarding_name_placeholder": "Votre nom",
@@ -123,7 +108,6 @@
   "onboarding_import": "Importer une clé existante",
   "onboarding_scan_qr": "Scanner un QR code",
   "onboarding_sync": "Synchroniser depuis un autre appareil",
-
   "recipient_title": "Sélectionner les destinataires",
   "recipient_search_placeholder": "Rechercher des clés...",
   "recipient_no_keys": "Aucune clé disponible.",
@@ -136,7 +120,6 @@
   "recipient_encrypt_btn_other": "Chiffrer pour {count} destinataires",
   "recipient_encrypting": "Chiffrement...",
   "recipient_encrypt_success": "Message chiffré et copié dans le presse-papiers.",
-
   "import_title": "Importer une clé",
   "import_textarea_placeholder": "Collez une clé PGP ASCII-armored ou un fichier de sauvegarde...",
   "import_or": "ou",
@@ -155,32 +138,26 @@
   "import_backup_success_one": "1 clé importée",
   "import_backup_success_other": "{count} clés importées",
   "import_backup_skipped": ", {count} déjà dans le trousseau",
-
   "passphrase_title": "Saisir la phrase secrète",
   "passphrase_desc": "Cette clé est protégée par une phrase secrète. Saisissez-la pour déchiffrer.",
   "passphrase_placeholder": "Phrase secrète",
   "passphrase_cancel": "Annuler",
   "passphrase_submit": "Déchiffrer",
-
   "decrypted_title": "Message déchiffré",
   "decrypted_copy": "Copier",
   "decrypted_copied": "Copié",
   "decrypted_close": "Fermer",
-
   "error_title": "Erreur",
   "error_fallback": "Une erreur inattendue s'est produite.",
   "error_ok": "OK",
-
   "confirm_default_title": "Confirmer",
   "confirm_default_message": "Êtes-vous sûr ?",
   "confirm_cancel": "Annuler",
   "confirm_delete": "Supprimer",
-
   "qr_title": "Export code QR",
   "qr_generating": "Génération du code QR...",
   "qr_desc": "Scannez ce code QR pour importer la clé publique.",
   "qr_close": "Fermer",
-
   "discovery_title": "Découvrir des clés",
   "discovery_placeholder": "Adresse e-mail ou nom...",
   "discovery_search": "Rechercher",
@@ -190,11 +167,9 @@
   "discovery_import_hint": "Pour importer une clé découverte, copiez sa clé publique et utilisez la fonction Importer dans la vue Clés.",
   "discovery_import_fail": "Impossible de récupérer les données de la clé pour l'import.",
   "discovery_close": "Fermer",
-
   "trust_unknown": "Inconnue",
   "trust_imported": "Importée",
   "trust_verified": "Vérifiée",
-
   "settings_title": "Paramètres",
   "settings_appearance": "Apparence",
   "settings_theme_system": "Système",
@@ -202,13 +177,11 @@
   "settings_theme_dark": "Sombre",
   "settings_close_to_tray_label": "Réduire dans la zone de notification",
   "settings_close_to_tray_desc": "Garder l'application dans la zone de notification lorsque vous fermez la fenêtre",
-
   "settings_clipboard": "Presse-papiers",
   "settings_auto_clear_label": "Effacer automatiquement le presse-papiers",
   "settings_auto_clear_desc": "Effacer les données sensibles du presse-papiers après déchiffrement",
   "settings_auto_clear_delay_label": "Délai d'effacement automatique",
   "settings_auto_clear_delay_desc": "Secondes avant l'effacement du presse-papiers",
-
   "settings_encryption": "Chiffrement",
   "settings_encrypt_to_self_label": "Chiffrer pour soi-même",
   "settings_encrypt_to_self_desc": "Toujours inclure votre propre clé comme destinataire",
@@ -217,22 +190,18 @@
   "settings_self_keys_count_other": "{count} clés sélectionnées.",
   "settings_include_armor_label": "Inclure les en-têtes armor",
   "settings_include_armor_desc": "Ajouter les métadonnées Version et Commentaire à la sortie PGP",
-
   "settings_security": "Sécurité",
   "settings_passphrase_cache_label": "Durée du cache de phrase secrète",
   "settings_passphrase_cache_desc": "Secondes de mémorisation des phrases secrètes (0 = désactivé)",
   "settings_clear_cache": "Vider le cache des phrases secrètes",
   "settings_cache_cleared": "Cache des phrases secrètes vidé.",
   "settings_cache_clear_failed": "Impossible de vider le cache : {error}",
-
   "settings_key_discovery": "Découverte de clés",
   "settings_keyserver_label": "URL du serveur de clés",
   "settings_keyserver_desc": "Utilisé pour la recherche et le téléversement de clés",
-
   "settings_language": "Langue",
   "settings_language_label": "Langue d'affichage",
   "settings_language_desc": "Choisissez la langue de l'interface",
-
   "settings_sync": "Synchronisation des clés",
   "settings_sync_desc": "Transférez vos clés entre appareils en toute sécurité.",
   "settings_sync_export": "Exporter les clés",
@@ -258,7 +227,6 @@
   "sync_error_no_passphrase": "Saisissez la phrase secrète affichée sur l'appareil exportateur.",
   "done": "Terminé",
   "cancel": "Annuler",
-
   "settings_opsec": "Mode OPSEC",
   "settings_opsec_desc": "Mode renforcé pour les environnements à haut risque. Les clés sont stockées uniquement en RAM et effacées à la fermeture.",
   "settings_opsec_enable": "Activer le mode OPSEC",
@@ -280,7 +248,6 @@
   "settings_proxy_success": "Connexion réussie !",
   "settings_proxy_failed": "Échec de la connexion : {error}",
   "settings_proxy_custom": "Personnalisé",
-
   "settings_about_title": "À propos",
   "settings_about": "KeychainPGP {version} — Chiffrement PGP centré sur le presse-papiers pour le bureau.",
   "settings_portable_badge": "Mode portable",
@@ -294,12 +261,10 @@
   "donate_eth": "Ethereum",
   "donate_xmr": "Monero",
   "donate_thanks": "Merci pour votre soutien !",
-
   "unnamed": "(sans nom)",
   "none_value": "(aucun)",
   "date_na": "N/D",
   "fingerprint_copy": "Copier l'empreinte",
-
   "kbd_ctrl": "Ctrl",
   "kbd_shift": "Maj"
 }

--- a/crates/keychainpgp-ui/frontend/messages/he.json
+++ b/crates/keychainpgp-ui/frontend/messages/he.json
@@ -1,57 +1,46 @@
 {
   "$schema": "https://inlang.com/schema/inlang-message-format",
-
   "loading": "טוען...",
   "ready": "מוכן",
-
   "nav_home": "הצפנה / פענוח",
   "nav_keys": "מפתחות",
   "nav_settings": "הגדרות",
-
   "home_title": "KeychainPGP",
   "home_tagline_clipboard": "העתק טקסט ולאחר מכן בחר פעולה למטה.",
   "home_tagline_compose": "הקלד את ההודעה שלך ולאחר מכן בחר פעולה למטה.",
   "mode_clipboard": "לוח",
   "mode_compose": "חיבור",
-
   "action_encrypt": "הצפנה",
   "action_decrypt": "פענוח",
   "action_sign": "חתימה",
   "action_verify": "אימות",
-
   "clipboard_label": "לוח",
   "clipboard_empty": "הלוח שלך ריק. העתק טקסט כדי להתחיל.",
   "clipboard_pgp_message": "הודעת PGP",
   "clipboard_signed_message": "הודעה חתומה",
   "clipboard_refresh": "רענן לוח",
-
   "compose_label": "חיבור",
   "compose_placeholder": "הקלד או הדבק את ההודעה כאן...",
   "compose_clear": "נקה",
-
   "encrypt_empty_clipboard": "הלוח ריק. העתק טקסט תחילה.",
   "encrypt_empty_compose": "שדה החיבור ריק. הקלד הודעה תחילה.",
   "encrypt_no_keys": "אין מפתחות זמינים. צור או ייבא מפתח תחילה.",
-
   "decrypt_empty_clipboard": "הלוח ריק. העתק הודעה מוצפנת תחילה.",
   "decrypt_empty_compose": "שדה החיבור ריק.",
   "decrypt_no_pgp": "לא זוהתה הודעת PGP.",
   "decrypt_in_progress": "מפענח...",
   "decrypt_success": "פוענח בהצלחה.",
   "decrypt_wrong_key_hint": "ודא שהמפתח הפרטי הנכון מיובא.",
-
   "sign_empty_clipboard": "הלוח ריק. העתק טקסט תחילה.",
   "sign_empty_compose": "שדה החיבור ריק.",
   "sign_no_key": "אין מפתח פרטי זמין. צור או ייבא מפתח תחילה.",
   "sign_in_progress": "חותם...",
   "sign_success_compose": "ההודעה נחתמה.",
-
   "verify_empty_clipboard": "הלוח ריק. העתק הודעה חתומה תחילה.",
   "verify_empty_compose": "שדה החיבור ריק.",
   "verify_in_progress": "מאמת...",
   "verify_success": "החתימה אומתה.",
   "verify_failed": "האימות נכשל.",
-
   "verify_modal_title": "אימות חתימה",
   "verify_valid_verified": "חתימה תקינה — מאומתת",
   "verify_valid_verified_desc": "הודעה זו נחתמה באמצעות מפתח מאומת.",
@@ -61,7 +50,6 @@
   "verify_signer_label": "חותם",
   "verify_email_label": "דוא\"ל",
   "verify_fingerprint_label": "טביעת אצבע",
-
   "keys_title": "מנהל מפתחות",
   "keys_generate": "צור",
   "keys_import_btn": "ייבא",
@@ -74,7 +62,6 @@
   "keys_section_contacts": "אנשי קשר",
   "keys_export_success": "המפתח הציבורי הועתק ללוח.",
   "keys_deleted": "המפתח נמחק.",
-
   "key_details_title": "פרטי מפתח",
   "key_details_btn": "פרטים",
   "key_export_btn": "ייצא מפתח ציבורי",
@@ -102,7 +89,6 @@
   "key_details_qr_btn": "קוד QR",
   "key_details_not_found": "המפתח לא נמצא.",
   "key_trust_update_failed": "עדכון האמון נכשל: {error}",
-
   "keygen_title": "יצירת זוג מפתחות חדש",
   "keygen_name_placeholder": "שם",
   "keygen_email_placeholder": "דוא\"ל",
@@ -112,7 +98,6 @@
   "keygen_submit": "צור",
   "keygen_loading": "יוצר...",
   "keygen_success": "זוג המפתחות נוצר בהצלחה!",
-
   "onboarding_title": "ברוכים הבאים ל-KeychainPGP",
   "onboarding_subtitle": "צור את זוג המפתחות הראשון שלך כדי להתחיל עם הצפנת לוח.",
   "onboarding_name_placeholder": "השם שלך",
@@ -123,7 +108,6 @@
   "onboarding_import": "ייבא מפתח קיים",
   "onboarding_scan_qr": "סרוק קוד QR",
   "onboarding_sync": "סנכרון ממכשיר אחר",
-
   "recipient_title": "בחירת נמענים",
   "recipient_search_placeholder": "חפש מפתחות...",
   "recipient_no_keys": "אין מפתחות זמינים.",
@@ -136,7 +120,6 @@
   "recipient_encrypt_btn_other": "הצפן עבור {count} נמענים",
   "recipient_encrypting": "מצפין...",
   "recipient_encrypt_success": "ההודעה הוצפנה והועתקה ללוח.",
-
   "import_title": "ייבוא מפתח",
   "import_textarea_placeholder": "הדבק מפתח PGP בפורמט ASCII-armored או קובץ גיבוי...",
   "import_or": "או",
@@ -155,32 +138,26 @@
   "import_backup_success_one": "מפתח אחד יובא",
   "import_backup_success_other": "{count} מפתחות יובאו",
   "import_backup_skipped": ", {count} כבר בצרור המפתחות",
-
   "passphrase_title": "הזנת סיסמה",
   "passphrase_desc": "מפתח זה מוגן בסיסמה. הזן אותה כדי לפענח.",
   "passphrase_placeholder": "סיסמה",
   "passphrase_cancel": "ביטול",
   "passphrase_submit": "פענח",
-
   "decrypted_title": "הודעה מפוענחת",
   "decrypted_copy": "העתק",
   "decrypted_copied": "הועתק",
   "decrypted_close": "סגור",
-
   "error_title": "שגיאה",
   "error_fallback": "אירעה שגיאה בלתי צפויה.",
   "error_ok": "אישור",
-
   "confirm_default_title": "אישור",
   "confirm_default_message": "האם אתה בטוח?",
   "confirm_cancel": "ביטול",
   "confirm_delete": "מחק",
-
   "qr_title": "ייצוא קוד QR",
   "qr_generating": "יוצר קוד QR...",
   "qr_desc": "סרוק קוד QR זה כדי לייבא את המפתח הציבורי.",
   "qr_close": "סגור",
-
   "discovery_title": "גילוי מפתחות",
   "discovery_placeholder": "כתובת דוא\"ל או שם...",
   "discovery_search": "חפש",
@@ -190,11 +167,9 @@
   "discovery_import_hint": "כדי לייבא מפתח שנמצא, העתק את המפתח הציבורי שלו והשתמש בפונקציית הייבוא בתצוגת המפתחות.",
   "discovery_import_fail": "לא ניתן לאחזר נתוני מפתח לייבוא.",
   "discovery_close": "סגור",
-
   "trust_unknown": "לא ידוע",
   "trust_imported": "מיובא",
   "trust_verified": "מאומת",
-
   "settings_title": "הגדרות",
   "settings_appearance": "מראה",
   "settings_theme_system": "מערכת",
@@ -202,13 +177,11 @@
   "settings_theme_dark": "כהה",
   "settings_close_to_tray_label": "סגור למגש המערכת",
   "settings_close_to_tray_desc": "השאר את האפליקציה פועלת במגש המערכת בעת סגירת החלון",
-
   "settings_clipboard": "לוח",
   "settings_auto_clear_label": "ניקוי לוח אוטומטי",
   "settings_auto_clear_desc": "נקה נתונים רגישים מהלוח לאחר פענוח",
   "settings_auto_clear_delay_label": "השהיית ניקוי אוטומטי",
   "settings_auto_clear_delay_desc": "שניות לפני ניקוי הלוח",
-
   "settings_encryption": "הצפנה",
   "settings_encrypt_to_self_label": "הצפן לעצמי",
   "settings_encrypt_to_self_desc": "כלול תמיד את המפתח שלך כנמען",
@@ -217,22 +190,18 @@
   "settings_self_keys_count_other": "{count} מפתחות נבחרו.",
   "settings_include_armor_label": "כלול כותרות armor",
   "settings_include_armor_desc": "הוסף מטא-נתוני גרסה והערה לפלט PGP",
-
   "settings_security": "אבטחה",
   "settings_passphrase_cache_label": "משך שמירת סיסמה במטמון",
   "settings_passphrase_cache_desc": "שניות לזכירת סיסמאות (0 = מושבת)",
   "settings_clear_cache": "נקה סיסמאות שמורות",
   "settings_cache_cleared": "מטמון הסיסמאות נוקה.",
   "settings_cache_clear_failed": "ניקוי המטמון נכשל: {error}",
-
   "settings_key_discovery": "גילוי מפתחות",
   "settings_keyserver_label": "כתובת שרת מפתחות",
   "settings_keyserver_desc": "משמש לחיפוש והעלאת מפתחות",
-
   "settings_language": "שפה",
   "settings_language_label": "שפת תצוגה",
   "settings_language_desc": "בחר את שפת הממשק",
-
   "settings_sync": "סנכרון מפתחות",
   "settings_sync_desc": "העבר את המפתחות שלך בין מכשירים בצורה מאובטחת.",
   "settings_sync_export": "ייצא מפתחות",
@@ -258,7 +227,6 @@
   "sync_error_no_passphrase": "הזן את סיסמת הסנכרון המוצגת במכשיר המייצא.",
   "done": "סיום",
   "cancel": "ביטול",
-
   "settings_opsec": "מצב OPSEC",
   "settings_opsec_desc": "מצב מוקשח לסביבות בסיכון גבוה. המפתחות מאוחסנים בזיכרון RAM בלבד ונמחקים ביציאה.",
   "settings_opsec_enable": "הפעל מצב OPSEC",
@@ -280,9 +248,8 @@
   "settings_proxy_success": "החיבור הצליח!",
   "settings_proxy_failed": "החיבור נכשל: {error}",
   "settings_proxy_custom": "מותאם אישית",
-
-  "settings_about": "KeychainPGP {version} — הצפנת PGP מבוססת לוח לשולחן העבודה.",
   "settings_about_title": "אודות",
+  "settings_about": "KeychainPGP {version} — הצפנת PGP מבוססת לוח לשולחן העבודה.",
   "settings_portable_badge": "מצב נייד",
   "donate_button": "תמכו בפרויקט",
   "donate_title": "תמכו ב-KeychainPGP",
@@ -294,12 +261,10 @@
   "donate_eth": "Ethereum",
   "donate_xmr": "Monero",
   "donate_thanks": "תודה על תמיכתכם!",
-
   "unnamed": "(ללא שם)",
   "none_value": "(אין)",
   "date_na": "לא זמין",
   "fingerprint_copy": "העתק טביעת אצבע",
-
   "kbd_ctrl": "Ctrl",
   "kbd_shift": "Shift"
 }

--- a/crates/keychainpgp-ui/frontend/messages/hi.json
+++ b/crates/keychainpgp-ui/frontend/messages/hi.json
@@ -1,57 +1,46 @@
 {
   "$schema": "https://inlang.com/schema/inlang-message-format",
-
   "loading": "लोड हो रहा है...",
   "ready": "तैयार",
-
   "nav_home": "एन्क्रिप्ट / डिक्रिप्ट",
   "nav_keys": "कुंजियाँ",
   "nav_settings": "सेटिंग्स",
-
   "home_title": "KeychainPGP",
   "home_tagline_clipboard": "टेक्स्ट कॉपी करें, फिर नीचे कोई क्रिया चुनें।",
   "home_tagline_compose": "अपना संदेश टाइप करें, फिर नीचे कोई क्रिया चुनें।",
   "mode_clipboard": "क्लिपबोर्ड",
   "mode_compose": "लिखें",
-
   "action_encrypt": "एन्क्रिप्ट",
   "action_decrypt": "डिक्रिप्ट",
   "action_sign": "हस्ताक्षर",
   "action_verify": "सत्यापन",
-
   "clipboard_label": "क्लिपबोर्ड",
   "clipboard_empty": "आपका क्लिपबोर्ड खाली है। शुरू करने के लिए कुछ टेक्स्ट कॉपी करें।",
   "clipboard_pgp_message": "PGP संदेश",
   "clipboard_signed_message": "हस्ताक्षरित संदेश",
   "clipboard_refresh": "क्लिपबोर्ड रिफ़्रेश करें",
-
   "compose_label": "लिखें",
   "compose_placeholder": "अपना संदेश यहाँ टाइप या पेस्ट करें...",
   "compose_clear": "साफ़ करें",
-
   "encrypt_empty_clipboard": "क्लिपबोर्ड खाली है। पहले कुछ टेक्स्ट कॉपी करें।",
   "encrypt_empty_compose": "लेखन फ़ील्ड खाली है। पहले कोई संदेश टाइप करें।",
   "encrypt_no_keys": "कोई कुंजी उपलब्ध नहीं है। पहले कुंजी बनाएँ या आयात करें।",
-
   "decrypt_empty_clipboard": "क्लिपबोर्ड खाली है। पहले एक एन्क्रिप्टेड संदेश कॉपी करें।",
   "decrypt_empty_compose": "लेखन फ़ील्ड खाली है।",
   "decrypt_no_pgp": "कोई PGP संदेश नहीं मिला।",
   "decrypt_in_progress": "डिक्रिप्ट हो रहा है...",
   "decrypt_success": "सफलतापूर्वक डिक्रिप्ट किया गया।",
   "decrypt_wrong_key_hint": "सुनिश्चित करें कि सही निजी कुंजी आयात की गई है।",
-
   "sign_empty_clipboard": "क्लिपबोर्ड खाली है। पहले कुछ टेक्स्ट कॉपी करें।",
   "sign_empty_compose": "लेखन फ़ील्ड खाली है।",
   "sign_no_key": "कोई निजी कुंजी उपलब्ध नहीं है। पहले एक बनाएँ या आयात करें।",
   "sign_in_progress": "हस्ताक्षर हो रहा है...",
   "sign_success_compose": "संदेश पर हस्ताक्षर किया गया।",
-
   "verify_empty_clipboard": "क्लिपबोर्ड खाली है। पहले एक हस्ताक्षरित संदेश कॉपी करें।",
   "verify_empty_compose": "लेखन फ़ील्ड खाली है।",
   "verify_in_progress": "सत्यापित हो रहा है...",
   "verify_success": "हस्ताक्षर सत्यापित।",
   "verify_failed": "सत्यापन विफल।",
-
   "verify_modal_title": "हस्ताक्षर सत्यापन",
   "verify_valid_verified": "वैध हस्ताक्षर — सत्यापित",
   "verify_valid_verified_desc": "यह संदेश एक सत्यापित कुंजी द्वारा हस्ताक्षरित है।",
@@ -61,7 +50,6 @@
   "verify_signer_label": "हस्ताक्षरकर्ता",
   "verify_email_label": "ईमेल",
   "verify_fingerprint_label": "फ़िंगरप्रिंट",
-
   "keys_title": "कुंजी प्रबंधक",
   "keys_generate": "बनाएँ",
   "keys_import_btn": "आयात",
@@ -74,7 +62,6 @@
   "keys_section_contacts": "संपर्क",
   "keys_export_success": "सार्वजनिक कुंजी क्लिपबोर्ड पर कॉपी की गई।",
   "keys_deleted": "कुंजी हटाई गई।",
-
   "key_details_title": "कुंजी विवरण",
   "key_details_btn": "विवरण",
   "key_export_btn": "सार्वजनिक कुंजी निर्यात करें",
@@ -102,7 +89,6 @@
   "key_details_qr_btn": "QR कोड",
   "key_details_not_found": "कुंजी नहीं मिली।",
   "key_trust_update_failed": "विश्वास अपडेट विफल: {error}",
-
   "keygen_title": "नया कुंजी युग्म बनाएँ",
   "keygen_name_placeholder": "नाम",
   "keygen_email_placeholder": "ईमेल",
@@ -112,7 +98,6 @@
   "keygen_submit": "बनाएँ",
   "keygen_loading": "बनाया जा रहा है...",
   "keygen_success": "कुंजी युग्म सफलतापूर्वक बनाया गया!",
-
   "onboarding_title": "KeychainPGP में आपका स्वागत है",
   "onboarding_subtitle": "क्लिपबोर्ड एन्क्रिप्शन शुरू करने के लिए अपना पहला कुंजी युग्म बनाएँ।",
   "onboarding_name_placeholder": "आपका नाम",
@@ -123,7 +108,6 @@
   "onboarding_import": "मौजूदा कुंजी आयात करें",
   "onboarding_scan_qr": "QR कोड स्कैन करें",
   "onboarding_sync": "किसी अन्य डिवाइस से सिंक करें",
-
   "recipient_title": "प्राप्तकर्ता चुनें",
   "recipient_search_placeholder": "कुंजियाँ खोजें...",
   "recipient_no_keys": "कोई कुंजी उपलब्ध नहीं है।",
@@ -136,7 +120,6 @@
   "recipient_encrypt_btn_other": "{count} प्राप्तकर्ताओं के लिए एन्क्रिप्ट करें",
   "recipient_encrypting": "एन्क्रिप्ट हो रहा है...",
   "recipient_encrypt_success": "संदेश एन्क्रिप्ट होकर क्लिपबोर्ड पर कॉपी किया गया।",
-
   "import_title": "कुंजी आयात करें",
   "import_textarea_placeholder": "ASCII-armored PGP कुंजी या बैकअप फ़ाइल पेस्ट करें...",
   "import_or": "या",
@@ -155,32 +138,26 @@
   "import_backup_success_one": "1 कुंजी आयात की गई",
   "import_backup_success_other": "{count} कुंजियाँ आयात की गईं",
   "import_backup_skipped": ", {count} पहले से कीरिंग में हैं",
-
   "passphrase_title": "पासफ़्रेज़ दर्ज करें",
   "passphrase_desc": "यह कुंजी पासफ़्रेज़ से सुरक्षित है। डिक्रिप्ट करने के लिए इसे दर्ज करें।",
   "passphrase_placeholder": "पासफ़्रेज़",
   "passphrase_cancel": "रद्द करें",
   "passphrase_submit": "डिक्रिप्ट",
-
   "decrypted_title": "डिक्रिप्ट किया गया संदेश",
   "decrypted_copy": "कॉपी",
   "decrypted_copied": "कॉपी किया गया",
   "decrypted_close": "बंद करें",
-
   "error_title": "त्रुटि",
   "error_fallback": "एक अनपेक्षित त्रुटि हुई।",
   "error_ok": "ठीक है",
-
   "confirm_default_title": "पुष्टि करें",
   "confirm_default_message": "क्या आप निश्चित हैं?",
   "confirm_cancel": "रद्द करें",
   "confirm_delete": "हटाएँ",
-
   "qr_title": "QR कोड निर्यात",
   "qr_generating": "QR कोड बनाया जा रहा है...",
   "qr_desc": "सार्वजनिक कुंजी आयात करने के लिए इस QR कोड को स्कैन करें।",
   "qr_close": "बंद करें",
-
   "discovery_title": "कुंजियाँ खोजें",
   "discovery_placeholder": "ईमेल पता या नाम...",
   "discovery_search": "खोजें",
@@ -190,11 +167,9 @@
   "discovery_import_hint": "खोजी गई कुंजी आयात करने के लिए, उसकी सार्वजनिक कुंजी कॉपी करें और कुंजी दृश्य में आयात फ़ंक्शन का उपयोग करें।",
   "discovery_import_fail": "आयात के लिए कुंजी डेटा प्राप्त नहीं हो सका।",
   "discovery_close": "बंद करें",
-
   "trust_unknown": "अज्ञात",
   "trust_imported": "आयातित",
   "trust_verified": "सत्यापित",
-
   "settings_title": "सेटिंग्स",
   "settings_appearance": "दिखावट",
   "settings_theme_system": "सिस्टम",
@@ -202,13 +177,11 @@
   "settings_theme_dark": "डार्क",
   "settings_close_to_tray_label": "ट्रे में बंद करें",
   "settings_close_to_tray_desc": "विंडो बंद करने पर ऐप को सिस्टम ट्रे में चालू रखें",
-
   "settings_clipboard": "क्लिपबोर्ड",
   "settings_auto_clear_label": "क्लिपबोर्ड स्वतः साफ़ करें",
   "settings_auto_clear_desc": "डिक्रिप्शन के बाद क्लिपबोर्ड से संवेदनशील डेटा साफ़ करें",
   "settings_auto_clear_delay_label": "स्वतः साफ़ विलंब",
   "settings_auto_clear_delay_desc": "क्लिपबोर्ड साफ़ होने से पहले सेकंड",
-
   "settings_encryption": "एन्क्रिप्शन",
   "settings_encrypt_to_self_label": "स्वयं को एन्क्रिप्ट करें",
   "settings_encrypt_to_self_desc": "हमेशा अपनी कुंजी को प्राप्तकर्ता के रूप में शामिल करें",
@@ -217,22 +190,18 @@
   "settings_self_keys_count_other": "{count} कुंजियाँ चयनित।",
   "settings_include_armor_label": "Armor हेडर शामिल करें",
   "settings_include_armor_desc": "PGP आउटपुट में संस्करण और टिप्पणी मेटाडेटा जोड़ें",
-
   "settings_security": "सुरक्षा",
   "settings_passphrase_cache_label": "पासफ़्रेज़ कैश अवधि",
   "settings_passphrase_cache_desc": "पासफ़्रेज़ याद रखने के सेकंड (0 = अक्षम)",
   "settings_clear_cache": "कैश किए गए पासफ़्रेज़ साफ़ करें",
   "settings_cache_cleared": "पासफ़्रेज़ कैश साफ़ किया गया।",
   "settings_cache_clear_failed": "कैश साफ़ करने में विफल: {error}",
-
   "settings_key_discovery": "कुंजी खोज",
   "settings_keyserver_label": "कीसर्वर URL",
   "settings_keyserver_desc": "कुंजी खोज और अपलोड के लिए उपयोग किया जाता है",
-
   "settings_language": "भाषा",
   "settings_language_label": "प्रदर्शन भाषा",
   "settings_language_desc": "इंटरफ़ेस के लिए भाषा चुनें",
-
   "settings_sync": "कुंजी सिंक",
   "settings_sync_desc": "अपनी कुंजियाँ उपकरणों के बीच सुरक्षित रूप से स्थानांतरित करें।",
   "settings_sync_export": "कुंजियाँ निर्यात करें",
@@ -258,7 +227,6 @@
   "sync_error_no_passphrase": "निर्यात करने वाले उपकरण पर दिखाया गया सिंक पासफ़्रेज़ दर्ज करें।",
   "done": "हो गया",
   "cancel": "रद्द करें",
-
   "settings_opsec": "OPSEC मोड",
   "settings_opsec_desc": "उच्च-जोखिम वातावरण के लिए सुदृढ़ मोड। कुंजियाँ केवल RAM में संग्रहीत होती हैं और बाहर निकलने पर मिटा दी जाती हैं।",
   "settings_opsec_enable": "OPSEC मोड सक्षम करें",
@@ -280,9 +248,8 @@
   "settings_proxy_success": "कनेक्शन सफल!",
   "settings_proxy_failed": "कनेक्शन विफल: {error}",
   "settings_proxy_custom": "कस्टम",
-
-  "settings_about": "KeychainPGP {version} — डेस्कटॉप के लिए क्लिपबोर्ड-प्रथम PGP एन्क्रिप्शन।",
   "settings_about_title": "परिचय",
+  "settings_about": "KeychainPGP {version} — डेस्कटॉप के लिए क्लिपबोर्ड-प्रथम PGP एन्क्रिप्शन।",
   "settings_portable_badge": "पोर्टेबल मोड",
   "donate_button": "इस परियोजना का समर्थन करें",
   "donate_title": "KeychainPGP का समर्थन करें",
@@ -294,12 +261,10 @@
   "donate_eth": "Ethereum",
   "donate_xmr": "Monero",
   "donate_thanks": "आपके समर्थन के लिए धन्यवाद!",
-
   "unnamed": "(अनामित)",
   "none_value": "(कोई नहीं)",
   "date_na": "उपलब्ध नहीं",
   "fingerprint_copy": "फ़िंगरप्रिंट कॉपी करें",
-
   "kbd_ctrl": "Ctrl",
   "kbd_shift": "Shift"
 }

--- a/crates/keychainpgp-ui/frontend/messages/it.json
+++ b/crates/keychainpgp-ui/frontend/messages/it.json
@@ -1,57 +1,46 @@
 {
   "$schema": "https://inlang.com/schema/inlang-message-format",
-
   "loading": "Caricamento...",
   "ready": "Pronto",
-
   "nav_home": "Cifra / Decifra",
   "nav_keys": "Chiavi",
   "nav_settings": "Impostazioni",
-
   "home_title": "KeychainPGP",
   "home_tagline_clipboard": "Copia del testo, poi scegli un'azione qui sotto.",
   "home_tagline_compose": "Scrivi il tuo messaggio, poi scegli un'azione qui sotto.",
   "mode_clipboard": "Appunti",
   "mode_compose": "Composizione",
-
   "action_encrypt": "CIFRA",
   "action_decrypt": "DECIFRA",
   "action_sign": "FIRMA",
   "action_verify": "VERIFICA",
-
   "clipboard_label": "Appunti",
   "clipboard_empty": "Gli appunti sono vuoti. Copia del testo per iniziare.",
   "clipboard_pgp_message": "Messaggio PGP",
   "clipboard_signed_message": "Messaggio firmato",
   "clipboard_refresh": "Aggiorna appunti",
-
   "compose_label": "Composizione",
   "compose_placeholder": "Scrivi o incolla il tuo messaggio qui...",
   "compose_clear": "Cancella",
-
   "encrypt_empty_clipboard": "Gli appunti sono vuoti. Copia prima del testo.",
   "encrypt_empty_compose": "Il campo di composizione è vuoto. Scrivi prima un messaggio.",
   "encrypt_no_keys": "Nessuna chiave disponibile. Genera o importa prima una chiave.",
-
   "decrypt_empty_clipboard": "Gli appunti sono vuoti. Copia prima un messaggio cifrato.",
   "decrypt_empty_compose": "Il campo di composizione è vuoto.",
   "decrypt_no_pgp": "Nessun messaggio PGP rilevato.",
   "decrypt_in_progress": "Decifrazione in corso...",
   "decrypt_success": "Decifrato con successo.",
   "decrypt_wrong_key_hint": "Assicurati di aver importato la chiave privata corretta.",
-
   "sign_empty_clipboard": "Gli appunti sono vuoti. Copia prima del testo.",
   "sign_empty_compose": "Il campo di composizione è vuoto.",
   "sign_no_key": "Nessuna chiave privata disponibile. Genera o importane prima una.",
   "sign_in_progress": "Firma in corso...",
   "sign_success_compose": "Messaggio firmato.",
-
   "verify_empty_clipboard": "Gli appunti sono vuoti. Copia prima un messaggio firmato.",
   "verify_empty_compose": "Il campo di composizione è vuoto.",
   "verify_in_progress": "Verifica in corso...",
   "verify_success": "Firma verificata.",
   "verify_failed": "Verifica fallita.",
-
   "verify_modal_title": "Verifica della firma",
   "verify_valid_verified": "Firma valida — Verificata",
   "verify_valid_verified_desc": "Questo messaggio è stato firmato da una chiave verificata.",
@@ -61,7 +50,6 @@
   "verify_signer_label": "Firmatario",
   "verify_email_label": "E-mail",
   "verify_fingerprint_label": "Impronta digitale",
-
   "keys_title": "Gestione chiavi",
   "keys_generate": "Genera",
   "keys_import_btn": "Importa",
@@ -74,7 +62,6 @@
   "keys_section_contacts": "Contatti",
   "keys_export_success": "Chiave pubblica copiata negli appunti.",
   "keys_deleted": "Chiave eliminata.",
-
   "key_details_title": "Dettagli chiave",
   "key_details_btn": "Dettagli",
   "key_export_btn": "Esporta chiave pubblica",
@@ -102,7 +89,6 @@
   "key_details_qr_btn": "Codice QR",
   "key_details_not_found": "Chiave non trovata.",
   "key_trust_update_failed": "Impossibile aggiornare la fiducia: {error}",
-
   "keygen_title": "Genera nuova coppia di chiavi",
   "keygen_name_placeholder": "Nome",
   "keygen_email_placeholder": "E-mail",
@@ -112,7 +98,6 @@
   "keygen_submit": "Genera",
   "keygen_loading": "Generazione in corso...",
   "keygen_success": "Coppia di chiavi generata con successo!",
-
   "onboarding_title": "Benvenuto in KeychainPGP",
   "onboarding_subtitle": "Genera la tua prima coppia di chiavi per iniziare a cifrare dagli appunti.",
   "onboarding_name_placeholder": "Il tuo nome",
@@ -123,7 +108,6 @@
   "onboarding_import": "Importa chiave esistente",
   "onboarding_scan_qr": "Scansiona codice QR",
   "onboarding_sync": "Sincronizza da un altro dispositivo",
-
   "recipient_title": "Seleziona destinatari",
   "recipient_search_placeholder": "Cerca chiavi...",
   "recipient_no_keys": "Nessuna chiave disponibile.",
@@ -136,7 +120,6 @@
   "recipient_encrypt_btn_other": "Cifra per {count} destinatari",
   "recipient_encrypting": "Cifratura in corso...",
   "recipient_encrypt_success": "Messaggio cifrato e copiato negli appunti.",
-
   "import_title": "Importa chiave",
   "import_textarea_placeholder": "Incolla una chiave PGP in formato ASCII-armored o un file di backup...",
   "import_or": "oppure",
@@ -155,32 +138,26 @@
   "import_backup_success_one": "1 chiave importata",
   "import_backup_success_other": "{count} chiavi importate",
   "import_backup_skipped": ", {count} già nel portachiavi",
-
   "passphrase_title": "Inserisci passphrase",
   "passphrase_desc": "Questa chiave è protetta da una passphrase. Inseriscila per decifrare.",
   "passphrase_placeholder": "Passphrase",
   "passphrase_cancel": "Annulla",
   "passphrase_submit": "Decifra",
-
   "decrypted_title": "Messaggio decifrato",
   "decrypted_copy": "Copia",
   "decrypted_copied": "Copiato",
   "decrypted_close": "Chiudi",
-
   "error_title": "Errore",
   "error_fallback": "Si è verificato un errore imprevisto.",
   "error_ok": "OK",
-
   "confirm_default_title": "Conferma",
   "confirm_default_message": "Sei sicuro?",
   "confirm_cancel": "Annulla",
   "confirm_delete": "Elimina",
-
   "qr_title": "Esportazione codice QR",
   "qr_generating": "Generazione del codice QR...",
   "qr_desc": "Scansiona questo codice QR per importare la chiave pubblica.",
   "qr_close": "Chiudi",
-
   "discovery_title": "Cerca chiavi",
   "discovery_placeholder": "Indirizzo e-mail o nome...",
   "discovery_search": "Cerca",
@@ -190,11 +167,9 @@
   "discovery_import_hint": "Per importare una chiave trovata, copia la sua chiave pubblica e usa la funzione Importa nella vista Chiavi.",
   "discovery_import_fail": "Impossibile recuperare i dati della chiave per l'importazione.",
   "discovery_close": "Chiudi",
-
   "trust_unknown": "Sconosciuta",
   "trust_imported": "Importata",
   "trust_verified": "Verificata",
-
   "settings_title": "Impostazioni",
   "settings_appearance": "Aspetto",
   "settings_theme_system": "Sistema",
@@ -202,13 +177,11 @@
   "settings_theme_dark": "Scuro",
   "settings_close_to_tray_label": "Chiudi nell'area di notifica",
   "settings_close_to_tray_desc": "Mantieni l'app nell'area di notifica quando chiudi la finestra",
-
   "settings_clipboard": "Appunti",
   "settings_auto_clear_label": "Svuota appunti automaticamente",
   "settings_auto_clear_desc": "Rimuovi i dati sensibili dagli appunti dopo la decifrazione",
   "settings_auto_clear_delay_label": "Ritardo svuotamento automatico",
   "settings_auto_clear_delay_desc": "Secondi prima che gli appunti vengano svuotati",
-
   "settings_encryption": "Cifratura",
   "settings_encrypt_to_self_label": "Cifra anche per se stessi",
   "settings_encrypt_to_self_desc": "Includi sempre la propria chiave come destinatario",
@@ -217,22 +190,18 @@
   "settings_self_keys_count_other": "{count} chiavi selezionate.",
   "settings_include_armor_label": "Includi intestazioni armor",
   "settings_include_armor_desc": "Aggiungi metadati di versione e commento all'output PGP",
-
   "settings_security": "Sicurezza",
   "settings_passphrase_cache_label": "Durata della cache delle passphrase",
   "settings_passphrase_cache_desc": "Secondi di memorizzazione delle passphrase (0 = disattivato)",
   "settings_clear_cache": "Cancella passphrase memorizzate",
   "settings_cache_cleared": "Cache delle passphrase cancellata.",
   "settings_cache_clear_failed": "Impossibile cancellare la cache: {error}",
-
   "settings_key_discovery": "Ricerca chiavi",
   "settings_keyserver_label": "URL del server di chiavi",
   "settings_keyserver_desc": "Utilizzato per la ricerca e il caricamento delle chiavi",
-
   "settings_language": "Lingua",
   "settings_language_label": "Lingua dell'interfaccia",
   "settings_language_desc": "Scegli la lingua dell'interfaccia",
-
   "settings_sync": "Sincronizzazione chiavi",
   "settings_sync_desc": "Trasferisci le tue chiavi tra dispositivi in modo sicuro.",
   "settings_sync_export": "Esporta chiavi",
@@ -258,7 +227,6 @@
   "sync_error_no_passphrase": "Inserisci la passphrase di sincronizzazione mostrata sul dispositivo di esportazione.",
   "done": "Fatto",
   "cancel": "Annulla",
-
   "settings_opsec": "Modalità OPSEC",
   "settings_opsec_desc": "Modalità rafforzata per ambienti ad alto rischio. Le chiavi sono conservate solo in RAM e cancellate all'uscita.",
   "settings_opsec_enable": "Attiva modalità OPSEC",
@@ -280,7 +248,6 @@
   "settings_proxy_success": "Connessione riuscita!",
   "settings_proxy_failed": "Connessione fallita: {error}",
   "settings_proxy_custom": "Personalizzato",
-
   "settings_about_title": "Informazioni",
   "settings_about": "KeychainPGP {version} — Cifratura PGP dagli appunti per desktop.",
   "settings_portable_badge": "Modalità portatile",
@@ -294,12 +261,10 @@
   "donate_eth": "Ethereum",
   "donate_xmr": "Monero",
   "donate_thanks": "Grazie per il tuo sostegno!",
-
   "unnamed": "(senza nome)",
   "none_value": "(nessuno)",
   "date_na": "N/D",
   "fingerprint_copy": "Copia impronta digitale",
-
   "kbd_ctrl": "Ctrl",
   "kbd_shift": "Maiusc"
 }

--- a/crates/keychainpgp-ui/frontend/messages/ja.json
+++ b/crates/keychainpgp-ui/frontend/messages/ja.json
@@ -1,57 +1,46 @@
 {
   "$schema": "https://inlang.com/schema/inlang-message-format",
-
   "loading": "読み込み中...",
   "ready": "準備完了",
-
   "nav_home": "暗号化 / 復号",
   "nav_keys": "鍵",
   "nav_settings": "設定",
-
   "home_title": "KeychainPGP",
   "home_tagline_clipboard": "テキストをコピーして、下のアクションを選択してください。",
   "home_tagline_compose": "メッセージを入力して、下のアクションを選択してください。",
   "mode_clipboard": "クリップボード",
   "mode_compose": "作成",
-
   "action_encrypt": "暗号化",
   "action_decrypt": "復号",
   "action_sign": "署名",
   "action_verify": "検証",
-
   "clipboard_label": "クリップボード",
   "clipboard_empty": "クリップボードが空です。テキストをコピーしてください。",
   "clipboard_pgp_message": "PGP メッセージ",
   "clipboard_signed_message": "署名済みメッセージ",
   "clipboard_refresh": "クリップボードを更新",
-
   "compose_label": "作成",
   "compose_placeholder": "ここにメッセージを入力または貼り付け...",
   "compose_clear": "クリア",
-
   "encrypt_empty_clipboard": "クリップボードが空です。先にテキストをコピーしてください。",
   "encrypt_empty_compose": "作成欄が空です。先にメッセージを入力してください。",
   "encrypt_no_keys": "利用可能な鍵がありません。先に鍵を生成またはインポートしてください。",
-
   "decrypt_empty_clipboard": "クリップボードが空です。先に暗号化メッセージをコピーしてください。",
   "decrypt_empty_compose": "作成欄が空です。",
   "decrypt_no_pgp": "PGP メッセージが検出されませんでした。",
   "decrypt_in_progress": "復号中...",
   "decrypt_success": "復号に成功しました。",
   "decrypt_wrong_key_hint": "正しい秘密鍵がインポートされていることを確認してください。",
-
   "sign_empty_clipboard": "クリップボードが空です。先にテキストをコピーしてください。",
   "sign_empty_compose": "作成欄が空です。",
   "sign_no_key": "利用可能な秘密鍵がありません。先に生成またはインポートしてください。",
   "sign_in_progress": "署名中...",
   "sign_success_compose": "メッセージに署名しました。",
-
   "verify_empty_clipboard": "クリップボードが空です。先に署名済みメッセージをコピーしてください。",
   "verify_empty_compose": "作成欄が空です。",
   "verify_in_progress": "検証中...",
   "verify_success": "署名の検証に成功しました。",
   "verify_failed": "検証に失敗しました。",
-
   "verify_modal_title": "署名の検証",
   "verify_valid_verified": "有効な署名 — 検証済み",
   "verify_valid_verified_desc": "このメッセージは検証済みの鍵で署名されています。",
@@ -61,7 +50,6 @@
   "verify_signer_label": "署名者",
   "verify_email_label": "メールアドレス",
   "verify_fingerprint_label": "フィンガープリント",
-
   "keys_title": "鍵の管理",
   "keys_generate": "生成",
   "keys_import_btn": "インポート",
@@ -74,7 +62,6 @@
   "keys_section_contacts": "連絡先",
   "keys_export_success": "公開鍵をクリップボードにコピーしました。",
   "keys_deleted": "鍵を削除しました。",
-
   "key_details_title": "鍵の詳細",
   "key_details_btn": "詳細",
   "key_export_btn": "公開鍵をエクスポート",
@@ -102,7 +89,6 @@
   "key_details_qr_btn": "QR コード",
   "key_details_not_found": "鍵が見つかりません。",
   "key_trust_update_failed": "信頼度の更新に失敗しました：{error}",
-
   "keygen_title": "新しい鍵ペアを生成",
   "keygen_name_placeholder": "名前",
   "keygen_email_placeholder": "メールアドレス",
@@ -112,7 +98,6 @@
   "keygen_submit": "生成",
   "keygen_loading": "生成中...",
   "keygen_success": "鍵ペアの生成に成功しました！",
-
   "onboarding_title": "KeychainPGP へようこそ",
   "onboarding_subtitle": "最初の鍵ペアを生成して、クリップボード暗号化を始めましょう。",
   "onboarding_name_placeholder": "お名前",
@@ -123,7 +108,6 @@
   "onboarding_import": "既存の鍵をインポート",
   "onboarding_scan_qr": "QRコードをスキャン",
   "onboarding_sync": "別のデバイスから同期",
-
   "recipient_title": "受信者を選択",
   "recipient_search_placeholder": "鍵を検索...",
   "recipient_no_keys": "利用可能な鍵がありません。",
@@ -136,7 +120,6 @@
   "recipient_encrypt_btn_other": "{count} 人の受信者に暗号化",
   "recipient_encrypting": "暗号化中...",
   "recipient_encrypt_success": "メッセージを暗号化してクリップボードにコピーしました。",
-
   "import_title": "鍵のインポート",
   "import_textarea_placeholder": "ASCII-armored PGP 鍵またはバックアップファイルを貼り付け...",
   "import_or": "または",
@@ -155,32 +138,26 @@
   "import_backup_success_one": "1 個の鍵をインポートしました",
   "import_backup_success_other": "{count} 個の鍵をインポートしました",
   "import_backup_skipped": "、{count} 個は既にキーリングに存在",
-
   "passphrase_title": "パスフレーズを入力",
   "passphrase_desc": "この鍵はパスフレーズで保護されています。復号するにはパスフレーズを入力してください。",
   "passphrase_placeholder": "パスフレーズ",
   "passphrase_cancel": "キャンセル",
   "passphrase_submit": "復号",
-
   "decrypted_title": "復号済みメッセージ",
   "decrypted_copy": "コピー",
   "decrypted_copied": "コピー済み",
   "decrypted_close": "閉じる",
-
   "error_title": "エラー",
   "error_fallback": "予期しないエラーが発生しました。",
   "error_ok": "OK",
-
   "confirm_default_title": "確認",
   "confirm_default_message": "よろしいですか？",
   "confirm_cancel": "キャンセル",
   "confirm_delete": "削除",
-
   "qr_title": "QR コードのエクスポート",
   "qr_generating": "QR コードを生成中...",
   "qr_desc": "この QR コードをスキャンして公開鍵をインポートできます。",
   "qr_close": "閉じる",
-
   "discovery_title": "鍵の検索",
   "discovery_placeholder": "メールアドレスまたは名前...",
   "discovery_search": "検索",
@@ -190,11 +167,9 @@
   "discovery_import_hint": "検索した鍵をインポートするには、公開鍵をコピーして鍵ビューのインポート機能をお使いください。",
   "discovery_import_fail": "インポート用の鍵データを取得できませんでした。",
   "discovery_close": "閉じる",
-
   "trust_unknown": "不明",
   "trust_imported": "インポート済み",
   "trust_verified": "検証済み",
-
   "settings_title": "設定",
   "settings_appearance": "外観",
   "settings_theme_system": "システムに従う",
@@ -202,13 +177,11 @@
   "settings_theme_dark": "ダーク",
   "settings_close_to_tray_label": "トレイに格納",
   "settings_close_to_tray_desc": "ウィンドウを閉じてもシステムトレイでアプリを実行し続ける",
-
   "settings_clipboard": "クリップボード",
   "settings_auto_clear_label": "クリップボードの自動クリア",
   "settings_auto_clear_desc": "復号後にクリップボードの機密データを自動的にクリアします",
   "settings_auto_clear_delay_label": "自動クリアの遅延",
   "settings_auto_clear_delay_desc": "クリップボードをクリアするまでの秒数",
-
   "settings_encryption": "暗号化",
   "settings_encrypt_to_self_label": "自分宛にも暗号化",
   "settings_encrypt_to_self_desc": "常に自分の鍵を受信者に含める",
@@ -217,22 +190,18 @@
   "settings_self_keys_count_other": "{count} 個の鍵を選択中。",
   "settings_include_armor_label": "armor ヘッダーを含める",
   "settings_include_armor_desc": "PGP 出力にバージョンとコメントのメタデータを追加",
-
   "settings_security": "セキュリティ",
   "settings_passphrase_cache_label": "パスフレーズのキャッシュ時間",
   "settings_passphrase_cache_desc": "パスフレーズを記憶する秒数（0 = 無効）",
   "settings_clear_cache": "キャッシュ済みパスフレーズをクリア",
   "settings_cache_cleared": "パスフレーズのキャッシュをクリアしました。",
   "settings_cache_clear_failed": "キャッシュのクリアに失敗しました：{error}",
-
   "settings_key_discovery": "鍵の検索",
   "settings_keyserver_label": "キーサーバー URL",
   "settings_keyserver_desc": "鍵の検索とアップロードに使用",
-
   "settings_language": "言語",
   "settings_language_label": "表示言語",
   "settings_language_desc": "インターフェースの言語を選択",
-
   "settings_sync": "鍵の同期",
   "settings_sync_desc": "デバイス間で安全に鍵を転送します。",
   "settings_sync_export": "鍵をエクスポート",
@@ -258,7 +227,6 @@
   "sync_error_no_passphrase": "エクスポート元のデバイスに表示された同期パスフレーズを入力してください。",
   "done": "完了",
   "cancel": "キャンセル",
-
   "settings_opsec": "OPSEC モード",
   "settings_opsec_desc": "高リスク環境向けの強化モード。鍵はメモリにのみ保存され、終了時に消去されます。",
   "settings_opsec_enable": "OPSEC モードを有効化",
@@ -280,9 +248,8 @@
   "settings_proxy_success": "接続に成功しました！",
   "settings_proxy_failed": "接続に失敗しました：{error}",
   "settings_proxy_custom": "カスタム",
-
-  "settings_about": "KeychainPGP {version} — デスクトップ向けクリップボード優先の PGP 暗号化ツール。",
   "settings_about_title": "概要",
+  "settings_about": "KeychainPGP {version} — デスクトップ向けクリップボード優先の PGP 暗号化ツール。",
   "settings_portable_badge": "ポータブルモード",
   "donate_button": "このプロジェクトを支援",
   "donate_title": "KeychainPGP を支援",
@@ -294,12 +261,10 @@
   "donate_eth": "Ethereum",
   "donate_xmr": "Monero",
   "donate_thanks": "ご支援ありがとうございます！",
-
   "unnamed": "（名前なし）",
   "none_value": "（なし）",
   "date_na": "N/A",
   "fingerprint_copy": "フィンガープリントをコピー",
-
   "kbd_ctrl": "Ctrl",
   "kbd_shift": "Shift"
 }

--- a/crates/keychainpgp-ui/frontend/messages/ko.json
+++ b/crates/keychainpgp-ui/frontend/messages/ko.json
@@ -1,57 +1,46 @@
 {
   "$schema": "https://inlang.com/schema/inlang-message-format",
-
   "loading": "로딩 중...",
   "ready": "준비 완료",
-
   "nav_home": "암호화 / 복호화",
   "nav_keys": "키 관리",
   "nav_settings": "설정",
-
   "home_title": "KeychainPGP",
   "home_tagline_clipboard": "텍스트를 복사한 후 아래에서 작업을 선택하세요.",
   "home_tagline_compose": "메시지를 입력한 후 아래에서 작업을 선택하세요.",
   "mode_clipboard": "클립보드",
   "mode_compose": "직접 입력",
-
   "action_encrypt": "암호화",
   "action_decrypt": "복호화",
   "action_sign": "서명",
   "action_verify": "검증",
-
   "clipboard_label": "클립보드",
   "clipboard_empty": "클립보드가 비어 있습니다. 텍스트를 복사하여 시작하세요.",
   "clipboard_pgp_message": "PGP 메시지",
   "clipboard_signed_message": "서명된 메시지",
   "clipboard_refresh": "클립보드 새로고침",
-
   "compose_label": "직접 입력",
   "compose_placeholder": "여기에 메시지를 입력하거나 붙여넣으세요...",
   "compose_clear": "지우기",
-
   "encrypt_empty_clipboard": "클립보드가 비어 있습니다. 먼저 텍스트를 복사하세요.",
   "encrypt_empty_compose": "입력란이 비어 있습니다. 먼저 메시지를 입력하세요.",
   "encrypt_no_keys": "사용 가능한 키가 없습니다. 먼저 키를 생성하거나 가져오세요.",
-
   "decrypt_empty_clipboard": "클립보드가 비어 있습니다. 먼저 암호화된 메시지를 복사하세요.",
   "decrypt_empty_compose": "입력란이 비어 있습니다.",
   "decrypt_no_pgp": "PGP 메시지가 감지되지 않았습니다.",
   "decrypt_in_progress": "복호화 중...",
   "decrypt_success": "복호화에 성공했습니다.",
   "decrypt_wrong_key_hint": "올바른 개인 키가 가져와져 있는지 확인하세요.",
-
   "sign_empty_clipboard": "클립보드가 비어 있습니다. 먼저 텍스트를 복사하세요.",
   "sign_empty_compose": "입력란이 비어 있습니다.",
   "sign_no_key": "사용 가능한 개인 키가 없습니다. 먼저 키를 생성하거나 가져오세요.",
   "sign_in_progress": "서명 중...",
   "sign_success_compose": "메시지가 서명되었습니다.",
-
   "verify_empty_clipboard": "클립보드가 비어 있습니다. 먼저 서명된 메시지를 복사하세요.",
   "verify_empty_compose": "입력란이 비어 있습니다.",
   "verify_in_progress": "검증 중...",
   "verify_success": "서명이 검증되었습니다.",
   "verify_failed": "검증에 실패했습니다.",
-
   "verify_modal_title": "서명 검증",
   "verify_valid_verified": "유효한 서명 — 검증됨",
   "verify_valid_verified_desc": "이 메시지는 검증된 키로 서명되었습니다.",
@@ -61,7 +50,6 @@
   "verify_signer_label": "서명자",
   "verify_email_label": "이메일",
   "verify_fingerprint_label": "지문",
-
   "keys_title": "키 관리자",
   "keys_generate": "생성",
   "keys_import_btn": "가져오기",
@@ -74,7 +62,6 @@
   "keys_section_contacts": "연락처",
   "keys_export_success": "공개 키가 클립보드에 복사되었습니다.",
   "keys_deleted": "키가 삭제되었습니다.",
-
   "key_details_title": "키 상세 정보",
   "key_details_btn": "상세",
   "key_export_btn": "공개 키 내보내기",
@@ -102,7 +89,6 @@
   "key_details_qr_btn": "QR 코드",
   "key_details_not_found": "키를 찾을 수 없습니다.",
   "key_trust_update_failed": "신뢰도 업데이트 실패: {error}",
-
   "keygen_title": "새 키 쌍 생성",
   "keygen_name_placeholder": "이름",
   "keygen_email_placeholder": "이메일",
@@ -112,7 +98,6 @@
   "keygen_submit": "생성",
   "keygen_loading": "생성 중...",
   "keygen_success": "키 쌍이 성공적으로 생성되었습니다!",
-
   "onboarding_title": "KeychainPGP에 오신 것을 환영합니다",
   "onboarding_subtitle": "클립보드 암호화를 시작하려면 첫 번째 키 쌍을 생성하세요.",
   "onboarding_name_placeholder": "이름",
@@ -123,7 +108,6 @@
   "onboarding_import": "기존 키 가져오기",
   "onboarding_scan_qr": "QR 코드 스캔",
   "onboarding_sync": "다른 기기에서 동기화",
-
   "recipient_title": "수신자 선택",
   "recipient_search_placeholder": "키 검색...",
   "recipient_no_keys": "사용 가능한 키가 없습니다.",
@@ -136,7 +120,6 @@
   "recipient_encrypt_btn_other": "{count}명의 수신자에게 암호화",
   "recipient_encrypting": "암호화 중...",
   "recipient_encrypt_success": "메시지가 암호화되어 클립보드에 복사되었습니다.",
-
   "import_title": "키 가져오기",
   "import_textarea_placeholder": "ASCII-armored PGP 키 또는 백업 파일을 붙여넣으세요...",
   "import_or": "또는",
@@ -155,32 +138,26 @@
   "import_backup_success_one": "1개의 키를 가져왔습니다",
   "import_backup_success_other": "{count}개의 키를 가져왔습니다",
   "import_backup_skipped": ", {count}개는 이미 키링에 있음",
-
   "passphrase_title": "암호문 입력",
   "passphrase_desc": "이 키는 암호문으로 보호되어 있습니다. 복호화하려면 암호문을 입력하세요.",
   "passphrase_placeholder": "암호문",
   "passphrase_cancel": "취소",
   "passphrase_submit": "복호화",
-
   "decrypted_title": "복호화된 메시지",
   "decrypted_copy": "복사",
   "decrypted_copied": "복사됨",
   "decrypted_close": "닫기",
-
   "error_title": "오류",
   "error_fallback": "예기치 않은 오류가 발생했습니다.",
   "error_ok": "확인",
-
   "confirm_default_title": "확인",
   "confirm_default_message": "계속하시겠습니까?",
   "confirm_cancel": "취소",
   "confirm_delete": "삭제",
-
   "qr_title": "QR 코드 내보내기",
   "qr_generating": "QR 코드 생성 중...",
   "qr_desc": "이 QR 코드를 스캔하여 공개 키를 가져오세요.",
   "qr_close": "닫기",
-
   "discovery_title": "키 검색",
   "discovery_placeholder": "이메일 주소 또는 이름...",
   "discovery_search": "검색",
@@ -190,11 +167,9 @@
   "discovery_import_hint": "검색된 키를 가져오려면 공개 키를 복사한 후 키 보기에서 가져오기 기능을 사용하세요.",
   "discovery_import_fail": "가져올 키 데이터를 검색할 수 없습니다.",
   "discovery_close": "닫기",
-
   "trust_unknown": "알 수 없음",
   "trust_imported": "가져옴",
   "trust_verified": "검증됨",
-
   "settings_title": "설정",
   "settings_appearance": "외관",
   "settings_theme_system": "시스템",
@@ -202,13 +177,11 @@
   "settings_theme_dark": "다크",
   "settings_close_to_tray_label": "트레이로 닫기",
   "settings_close_to_tray_desc": "창을 닫아도 시스템 트레이에서 앱을 계속 실행",
-
   "settings_clipboard": "클립보드",
   "settings_auto_clear_label": "클립보드 자동 지우기",
   "settings_auto_clear_desc": "복호화 후 클립보드에서 민감한 데이터 지우기",
   "settings_auto_clear_delay_label": "자동 지우기 지연 시간",
   "settings_auto_clear_delay_desc": "클립보드가 지워지기까지의 시간(초)",
-
   "settings_encryption": "암호화",
   "settings_encrypt_to_self_label": "자신에게도 암호화",
   "settings_encrypt_to_self_desc": "항상 자신의 키를 수신자에 포함",
@@ -217,22 +190,18 @@
   "settings_self_keys_count_other": "{count}개의 키가 선택되었습니다.",
   "settings_include_armor_label": "아머 헤더 포함",
   "settings_include_armor_desc": "PGP 출력에 버전 및 설명 메타데이터 추가",
-
   "settings_security": "보안",
   "settings_passphrase_cache_label": "암호문 캐시 기간",
   "settings_passphrase_cache_desc": "암호문을 기억하는 시간(초, 0 = 비활성화)",
   "settings_clear_cache": "캐시된 암호문 지우기",
   "settings_cache_cleared": "암호문 캐시가 지워졌습니다.",
   "settings_cache_clear_failed": "캐시 지우기 실패: {error}",
-
   "settings_key_discovery": "키 검색",
   "settings_keyserver_label": "키 서버 URL",
   "settings_keyserver_desc": "키 검색 및 업로드에 사용",
-
   "settings_language": "언어",
   "settings_language_label": "표시 언어",
   "settings_language_desc": "인터페이스 언어 선택",
-
   "settings_sync": "키 동기화",
   "settings_sync_desc": "기기 간에 키를 안전하게 전송합니다.",
   "settings_sync_export": "키 내보내기",
@@ -258,7 +227,6 @@
   "sync_error_no_passphrase": "내보내기 기기에 표시된 동기화 암호문을 입력하세요.",
   "done": "완료",
   "cancel": "취소",
-
   "settings_opsec": "OPSEC 모드",
   "settings_opsec_desc": "고위험 환경을 위한 강화 모드. 키는 메모리에만 저장되며 종료 시 삭제됩니다.",
   "settings_opsec_enable": "OPSEC 모드 활성화",
@@ -280,9 +248,8 @@
   "settings_proxy_success": "연결에 성공했습니다!",
   "settings_proxy_failed": "연결 실패: {error}",
   "settings_proxy_custom": "사용자 지정",
-
-  "settings_about": "KeychainPGP {version} — 데스크톱용 클립보드 중심 PGP 암호화.",
   "settings_about_title": "정보",
+  "settings_about": "KeychainPGP {version} — 데스크톱용 클립보드 중심 PGP 암호화.",
   "settings_portable_badge": "포터블 모드",
   "donate_button": "이 프로젝트 지원하기",
   "donate_title": "KeychainPGP 지원",
@@ -294,12 +261,10 @@
   "donate_eth": "Ethereum",
   "donate_xmr": "Monero",
   "donate_thanks": "후원해 주셔서 감사합니다!",
-
   "unnamed": "(이름 없음)",
   "none_value": "(없음)",
   "date_na": "해당 없음",
   "fingerprint_copy": "지문 복사",
-
   "kbd_ctrl": "Ctrl",
   "kbd_shift": "Shift"
 }

--- a/crates/keychainpgp-ui/frontend/messages/nl.json
+++ b/crates/keychainpgp-ui/frontend/messages/nl.json
@@ -1,57 +1,46 @@
 {
   "$schema": "https://inlang.com/schema/inlang-message-format",
-
   "loading": "Laden...",
   "ready": "Gereed",
-
   "nav_home": "Versleutelen / Ontsleutelen",
   "nav_keys": "Sleutels",
   "nav_settings": "Instellingen",
-
   "home_title": "KeychainPGP",
   "home_tagline_clipboard": "Kopieer tekst en kies hieronder een actie.",
   "home_tagline_compose": "Typ uw bericht en kies hieronder een actie.",
   "mode_clipboard": "Klembord",
   "mode_compose": "Opstellen",
-
   "action_encrypt": "VERSLEUTELEN",
   "action_decrypt": "ONTSLEUTELEN",
   "action_sign": "ONDERTEKENEN",
   "action_verify": "VERIFIËREN",
-
   "clipboard_label": "Klembord",
   "clipboard_empty": "Uw klembord is leeg. Kopieer tekst om te beginnen.",
   "clipboard_pgp_message": "PGP-bericht",
   "clipboard_signed_message": "Ondertekend bericht",
   "clipboard_refresh": "Klembord vernieuwen",
-
   "compose_label": "Opstellen",
   "compose_placeholder": "Typ of plak hier uw bericht...",
   "compose_clear": "Wissen",
-
   "encrypt_empty_clipboard": "Het klembord is leeg. Kopieer eerst tekst.",
   "encrypt_empty_compose": "Het tekstveld is leeg. Typ eerst een bericht.",
   "encrypt_no_keys": "Geen sleutels beschikbaar. Genereer of importeer eerst een sleutel.",
-
   "decrypt_empty_clipboard": "Het klembord is leeg. Kopieer eerst een versleuteld bericht.",
   "decrypt_empty_compose": "Het tekstveld is leeg.",
   "decrypt_no_pgp": "Geen PGP-bericht gedetecteerd.",
   "decrypt_in_progress": "Ontsleutelen...",
   "decrypt_success": "Ontsleuteling geslaagd.",
   "decrypt_wrong_key_hint": "Controleer of u de juiste privésleutel hebt geïmporteerd.",
-
   "sign_empty_clipboard": "Het klembord is leeg. Kopieer eerst tekst.",
   "sign_empty_compose": "Het tekstveld is leeg.",
   "sign_no_key": "Geen privésleutel beschikbaar. Genereer of importeer er eerst een.",
   "sign_in_progress": "Ondertekenen...",
   "sign_success_compose": "Bericht ondertekend.",
-
   "verify_empty_clipboard": "Het klembord is leeg. Kopieer eerst een ondertekend bericht.",
   "verify_empty_compose": "Het tekstveld is leeg.",
   "verify_in_progress": "Verifiëren...",
   "verify_success": "Handtekening geverifieerd.",
   "verify_failed": "Verificatie mislukt.",
-
   "verify_modal_title": "Handtekeningverificatie",
   "verify_valid_verified": "Geldige handtekening — Geverifieerd",
   "verify_valid_verified_desc": "Dit bericht is ondertekend met een geverifieerde sleutel.",
@@ -61,7 +50,6 @@
   "verify_signer_label": "Ondertekenaar",
   "verify_email_label": "E-mail",
   "verify_fingerprint_label": "Vingerafdruk",
-
   "keys_title": "Sleutelbeheer",
   "keys_generate": "Genereren",
   "keys_import_btn": "Importeren",
@@ -74,7 +62,6 @@
   "keys_section_contacts": "Contacten",
   "keys_export_success": "Publieke sleutel gekopieerd naar klembord.",
   "keys_deleted": "Sleutel verwijderd.",
-
   "key_details_title": "Sleuteldetails",
   "key_details_btn": "Details",
   "key_export_btn": "Publieke sleutel exporteren",
@@ -102,7 +89,6 @@
   "key_details_qr_btn": "QR-code",
   "key_details_not_found": "Sleutel niet gevonden.",
   "key_trust_update_failed": "Vertrouwen bijwerken mislukt: {error}",
-
   "keygen_title": "Nieuw sleutelpaar genereren",
   "keygen_name_placeholder": "Naam",
   "keygen_email_placeholder": "E-mail",
@@ -112,7 +98,6 @@
   "keygen_submit": "Genereren",
   "keygen_loading": "Genereren...",
   "keygen_success": "Sleutelpaar succesvol gegenereerd!",
-
   "onboarding_title": "Welkom bij KeychainPGP",
   "onboarding_subtitle": "Genereer uw eerste sleutelpaar om te beginnen met klembordversleuteling.",
   "onboarding_name_placeholder": "Uw naam",
@@ -123,7 +108,6 @@
   "onboarding_import": "Bestaande sleutel importeren",
   "onboarding_scan_qr": "QR-code scannen",
   "onboarding_sync": "Synchroniseren vanaf een ander apparaat",
-
   "recipient_title": "Ontvangers selecteren",
   "recipient_search_placeholder": "Sleutels zoeken...",
   "recipient_no_keys": "Geen sleutels beschikbaar.",
@@ -136,7 +120,6 @@
   "recipient_encrypt_btn_other": "Versleutelen voor {count} ontvangers",
   "recipient_encrypting": "Versleutelen...",
   "recipient_encrypt_success": "Bericht versleuteld en gekopieerd naar klembord.",
-
   "import_title": "Sleutel importeren",
   "import_textarea_placeholder": "Plak een ASCII-armored PGP-sleutel of back-upbestand...",
   "import_or": "of",
@@ -155,32 +138,26 @@
   "import_backup_success_one": "1 sleutel geïmporteerd",
   "import_backup_success_other": "{count} sleutels geïmporteerd",
   "import_backup_skipped": ", {count} al in sleutelbos",
-
   "passphrase_title": "Wachtwoordzin invoeren",
   "passphrase_desc": "Deze sleutel is beveiligd met een wachtwoordzin. Voer deze in om te ontsleutelen.",
   "passphrase_placeholder": "Wachtwoordzin",
   "passphrase_cancel": "Annuleren",
   "passphrase_submit": "Ontsleutelen",
-
   "decrypted_title": "Ontsleuteld bericht",
   "decrypted_copy": "Kopiëren",
   "decrypted_copied": "Gekopieerd",
   "decrypted_close": "Sluiten",
-
   "error_title": "Fout",
   "error_fallback": "Er is een onverwachte fout opgetreden.",
   "error_ok": "OK",
-
   "confirm_default_title": "Bevestigen",
   "confirm_default_message": "Weet u het zeker?",
   "confirm_cancel": "Annuleren",
   "confirm_delete": "Verwijderen",
-
   "qr_title": "QR-code exporteren",
   "qr_generating": "QR-code genereren...",
   "qr_desc": "Scan deze QR-code om de publieke sleutel te importeren.",
   "qr_close": "Sluiten",
-
   "discovery_title": "Sleutels ontdekken",
   "discovery_placeholder": "E-mailadres of naam...",
   "discovery_search": "Zoeken",
@@ -190,11 +167,9 @@
   "discovery_import_hint": "Om een ontdekte sleutel te importeren, kopieer de publieke sleutel en gebruik de importfunctie in het scherm Sleutels.",
   "discovery_import_fail": "Kon de sleutelgegevens niet ophalen voor import.",
   "discovery_close": "Sluiten",
-
   "trust_unknown": "Onbekend",
   "trust_imported": "Geïmporteerd",
   "trust_verified": "Geverifieerd",
-
   "settings_title": "Instellingen",
   "settings_appearance": "Weergave",
   "settings_theme_system": "Systeem",
@@ -202,13 +177,11 @@
   "settings_theme_dark": "Donker",
   "settings_close_to_tray_label": "Sluiten naar systeemvak",
   "settings_close_to_tray_desc": "De app in het systeemvak laten draaien wanneer u het venster sluit",
-
   "settings_clipboard": "Klembord",
   "settings_auto_clear_label": "Klembord automatisch wissen",
   "settings_auto_clear_desc": "Gevoelige gegevens van het klembord wissen na ontsleuteling",
   "settings_auto_clear_delay_label": "Vertraging automatisch wissen",
   "settings_auto_clear_delay_desc": "Seconden voordat het klembord wordt gewist",
-
   "settings_encryption": "Versleuteling",
   "settings_encrypt_to_self_label": "Naar uzelf versleutelen",
   "settings_encrypt_to_self_desc": "Altijd uw eigen sleutel als ontvanger opnemen",
@@ -217,22 +190,18 @@
   "settings_self_keys_count_other": "{count} sleutels geselecteerd.",
   "settings_include_armor_label": "Armor-headers opnemen",
   "settings_include_armor_desc": "Versie- en commentaarmetadata toevoegen aan PGP-uitvoer",
-
   "settings_security": "Beveiliging",
   "settings_passphrase_cache_label": "Cacheduur wachtwoordzin",
   "settings_passphrase_cache_desc": "Seconden om wachtwoordzinnen te onthouden (0 = uitgeschakeld)",
   "settings_clear_cache": "Gecachte wachtwoordzinnen wissen",
   "settings_cache_cleared": "Cache van wachtwoordzinnen gewist.",
   "settings_cache_clear_failed": "Cache wissen mislukt: {error}",
-
   "settings_key_discovery": "Sleutelontdekking",
   "settings_keyserver_label": "Sleutelserver-URL",
   "settings_keyserver_desc": "Gebruikt voor het zoeken en uploaden van sleutels",
-
   "settings_language": "Taal",
   "settings_language_label": "Weergavetaal",
   "settings_language_desc": "Kies de taal voor de interface",
-
   "settings_sync": "Sleutelsynchronisatie",
   "settings_sync_desc": "Draag uw sleutels veilig over tussen apparaten.",
   "settings_sync_export": "Sleutels exporteren",
@@ -258,7 +227,6 @@
   "sync_error_no_passphrase": "Voer de synchronisatiewachtwoordzin in die op het exporterende apparaat wordt getoond.",
   "done": "Gereed",
   "cancel": "Annuleren",
-
   "settings_opsec": "OPSEC-modus",
   "settings_opsec_desc": "Verharde modus voor risicovolle omgevingen. Sleutels worden alleen in RAM opgeslagen en gewist bij afsluiten.",
   "settings_opsec_enable": "OPSEC-modus inschakelen",
@@ -280,9 +248,8 @@
   "settings_proxy_success": "Verbinding geslaagd!",
   "settings_proxy_failed": "Verbinding mislukt: {error}",
   "settings_proxy_custom": "Aangepast",
-
-  "settings_about": "KeychainPGP {version} — Klembordgerichte PGP-versleuteling voor desktop.",
   "settings_about_title": "Over",
+  "settings_about": "KeychainPGP {version} — Klembordgerichte PGP-versleuteling voor desktop.",
   "settings_portable_badge": "Draagbare modus",
   "donate_button": "Steun dit project",
   "donate_title": "Steun KeychainPGP",
@@ -294,12 +261,10 @@
   "donate_eth": "Ethereum",
   "donate_xmr": "Monero",
   "donate_thanks": "Bedankt voor uw steun!",
-
   "unnamed": "(naamloos)",
   "none_value": "(geen)",
   "date_na": "N.v.t.",
   "fingerprint_copy": "Vingerafdruk kopiëren",
-
   "kbd_ctrl": "Ctrl",
   "kbd_shift": "Shift"
 }

--- a/crates/keychainpgp-ui/frontend/messages/pl.json
+++ b/crates/keychainpgp-ui/frontend/messages/pl.json
@@ -1,57 +1,46 @@
 {
   "$schema": "https://inlang.com/schema/inlang-message-format",
-
   "loading": "Wczytywanie...",
   "ready": "Gotowe",
-
   "nav_home": "Szyfrowanie / Deszyfrowanie",
   "nav_keys": "Klucze",
   "nav_settings": "Ustawienia",
-
   "home_title": "KeychainPGP",
   "home_tagline_clipboard": "Skopiuj tekst, a następnie wybierz akcję poniżej.",
   "home_tagline_compose": "Wpisz wiadomość, a następnie wybierz akcję poniżej.",
   "mode_clipboard": "Schowek",
   "mode_compose": "Edytor",
-
   "action_encrypt": "ZASZYFRUJ",
   "action_decrypt": "ODSZYFRUJ",
   "action_sign": "PODPISZ",
   "action_verify": "ZWERYFIKUJ",
-
   "clipboard_label": "Schowek",
   "clipboard_empty": "Schowek jest pusty. Skopiuj tekst, aby rozpocząć.",
   "clipboard_pgp_message": "Wiadomość PGP",
   "clipboard_signed_message": "Podpisana wiadomość",
   "clipboard_refresh": "Odśwież schowek",
-
   "compose_label": "Edytor",
   "compose_placeholder": "Wpisz lub wklej wiadomość...",
   "compose_clear": "Wyczyść",
-
   "encrypt_empty_clipboard": "Schowek jest pusty. Najpierw skopiuj tekst.",
   "encrypt_empty_compose": "Pole edytora jest puste. Najpierw wpisz wiadomość.",
   "encrypt_no_keys": "Brak dostępnych kluczy. Najpierw wygeneruj lub zaimportuj klucz.",
-
   "decrypt_empty_clipboard": "Schowek jest pusty. Najpierw skopiuj zaszyfrowaną wiadomość.",
   "decrypt_empty_compose": "Pole edytora jest puste.",
   "decrypt_no_pgp": "Nie wykryto wiadomości PGP.",
   "decrypt_in_progress": "Odszyfrowywanie...",
   "decrypt_success": "Pomyślnie odszyfrowano.",
   "decrypt_wrong_key_hint": "Upewnij się, że masz zaimportowany właściwy klucz prywatny.",
-
   "sign_empty_clipboard": "Schowek jest pusty. Najpierw skopiuj tekst.",
   "sign_empty_compose": "Pole edytora jest puste.",
   "sign_no_key": "Brak klucza prywatnego. Najpierw wygeneruj lub zaimportuj klucz.",
   "sign_in_progress": "Podpisywanie...",
   "sign_success_compose": "Wiadomość podpisana.",
-
   "verify_empty_clipboard": "Schowek jest pusty. Najpierw skopiuj podpisaną wiadomość.",
   "verify_empty_compose": "Pole edytora jest puste.",
   "verify_in_progress": "Weryfikacja...",
   "verify_success": "Podpis zweryfikowany.",
   "verify_failed": "Weryfikacja nie powiodła się.",
-
   "verify_modal_title": "Weryfikacja podpisu",
   "verify_valid_verified": "Prawidłowy podpis — zweryfikowany klucz",
   "verify_valid_verified_desc": "Ta wiadomość została podpisana zweryfikowanym kluczem.",
@@ -61,7 +50,6 @@
   "verify_signer_label": "Sygnatariusz",
   "verify_email_label": "E-mail",
   "verify_fingerprint_label": "Odcisk",
-
   "keys_title": "Menedżer kluczy",
   "keys_generate": "Generuj",
   "keys_import_btn": "Importuj",
@@ -74,7 +62,6 @@
   "keys_section_contacts": "Kontakty",
   "keys_export_success": "Klucz publiczny skopiowany do schowka.",
   "keys_deleted": "Klucz usunięty.",
-
   "key_details_title": "Szczegóły klucza",
   "key_details_btn": "Szczegóły",
   "key_export_btn": "Eksportuj klucz publiczny",
@@ -102,7 +89,6 @@
   "key_details_qr_btn": "Kod QR",
   "key_details_not_found": "Nie znaleziono klucza.",
   "key_trust_update_failed": "Nie udało się zaktualizować zaufania: {error}",
-
   "keygen_title": "Generowanie nowej pary kluczy",
   "keygen_name_placeholder": "Nazwa",
   "keygen_email_placeholder": "E-mail",
@@ -112,7 +98,6 @@
   "keygen_submit": "Generuj",
   "keygen_loading": "Generowanie...",
   "keygen_success": "Para kluczy wygenerowana pomyślnie!",
-
   "onboarding_title": "Witaj w KeychainPGP",
   "onboarding_subtitle": "Wygeneruj swoją pierwszą parę kluczy, aby rozpocząć szyfrowanie przez schowek.",
   "onboarding_name_placeholder": "Twoje imię",
@@ -123,7 +108,6 @@
   "onboarding_import": "Importuj istniejący klucz",
   "onboarding_scan_qr": "Skanuj kod QR",
   "onboarding_sync": "Synchronizuj z innego urządzenia",
-
   "recipient_title": "Wybór odbiorców",
   "recipient_search_placeholder": "Szukaj kluczy...",
   "recipient_no_keys": "Brak dostępnych kluczy.",
@@ -136,7 +120,6 @@
   "recipient_encrypt_btn_other": "Zaszyfruj dla {count} odbiorców",
   "recipient_encrypting": "Szyfrowanie...",
   "recipient_encrypt_success": "Wiadomość zaszyfrowana i skopiowana do schowka.",
-
   "import_title": "Import klucza",
   "import_textarea_placeholder": "Wklej klucz PGP w formacie ASCII-armored lub plik kopii zapasowej...",
   "import_or": "lub",
@@ -155,32 +138,26 @@
   "import_backup_success_one": "Zaimportowano 1 klucz",
   "import_backup_success_other": "Zaimportowano kluczy: {count}",
   "import_backup_skipped": ", {count} już w pęku kluczy",
-
   "passphrase_title": "Wprowadź hasło",
   "passphrase_desc": "Ten klucz jest chroniony hasłem. Wprowadź je, aby odszyfrować.",
   "passphrase_placeholder": "Hasło",
   "passphrase_cancel": "Anuluj",
   "passphrase_submit": "Odszyfruj",
-
   "decrypted_title": "Odszyfrowana wiadomość",
   "decrypted_copy": "Kopiuj",
   "decrypted_copied": "Skopiowano",
   "decrypted_close": "Zamknij",
-
   "error_title": "Błąd",
   "error_fallback": "Wystąpił nieoczekiwany błąd.",
   "error_ok": "OK",
-
   "confirm_default_title": "Potwierdzenie",
   "confirm_default_message": "Czy na pewno?",
   "confirm_cancel": "Anuluj",
   "confirm_delete": "Usuń",
-
   "qr_title": "Eksport kodu QR",
   "qr_generating": "Generowanie kodu QR...",
   "qr_desc": "Zeskanuj ten kod QR, aby zaimportować klucz publiczny.",
   "qr_close": "Zamknij",
-
   "discovery_title": "Wyszukiwanie kluczy",
   "discovery_placeholder": "Adres e-mail lub nazwa...",
   "discovery_search": "Szukaj",
@@ -190,11 +167,9 @@
   "discovery_import_hint": "Aby zaimportować znaleziony klucz, skopiuj jego klucz publiczny i użyj funkcji importu w zakładce Klucze.",
   "discovery_import_fail": "Nie udało się pobrać danych klucza do importu.",
   "discovery_close": "Zamknij",
-
   "trust_unknown": "Nieznany",
   "trust_imported": "Zaimportowany",
   "trust_verified": "Zweryfikowany",
-
   "settings_title": "Ustawienia",
   "settings_appearance": "Wygląd",
   "settings_theme_system": "Systemowy",
@@ -202,13 +177,11 @@
   "settings_theme_dark": "Ciemny",
   "settings_close_to_tray_label": "Zamknij do zasobnika",
   "settings_close_to_tray_desc": "Pozostaw aplikację w zasobniku systemowym po zamknięciu okna",
-
   "settings_clipboard": "Schowek",
   "settings_auto_clear_label": "Automatyczne czyszczenie schowka",
   "settings_auto_clear_desc": "Usuwaj poufne dane ze schowka po odszyfrowaniu",
   "settings_auto_clear_delay_label": "Opóźnienie automatycznego czyszczenia",
   "settings_auto_clear_delay_desc": "Sekundy do wyczyszczenia schowka",
-
   "settings_encryption": "Szyfrowanie",
   "settings_encrypt_to_self_label": "Szyfruj dla siebie",
   "settings_encrypt_to_self_desc": "Zawsze dołączaj własny klucz jako odbiorcę",
@@ -217,22 +190,18 @@
   "settings_self_keys_count_other": "Wybranych kluczy: {count}.",
   "settings_include_armor_label": "Dołączaj nagłówki ASCII-armored",
   "settings_include_armor_desc": "Dodawaj metadane Version i Comment do wyjścia PGP",
-
   "settings_security": "Bezpieczeństwo",
   "settings_passphrase_cache_label": "Czas buforowania hasła",
   "settings_passphrase_cache_desc": "Sekundy zapamiętywania haseł (0 = wyłączone)",
   "settings_clear_cache": "Wyczyść bufor haseł",
   "settings_cache_cleared": "Bufor haseł wyczyszczony.",
   "settings_cache_clear_failed": "Nie udało się wyczyścić bufora: {error}",
-
   "settings_key_discovery": "Wyszukiwanie kluczy",
   "settings_keyserver_label": "Adres URL serwera kluczy",
   "settings_keyserver_desc": "Używany do wyszukiwania i przesyłania kluczy",
-
   "settings_language": "Język",
   "settings_language_label": "Język interfejsu",
   "settings_language_desc": "Wybierz język interfejsu",
-
   "settings_sync": "Synchronizacja kluczy",
   "settings_sync_desc": "Bezpiecznie przenoś klucze między urządzeniami.",
   "settings_sync_export": "Eksportuj klucze",
@@ -258,7 +227,6 @@
   "sync_error_no_passphrase": "Wprowadź hasło synchronizacji wyświetlone na urządzeniu eksportującym.",
   "done": "Gotowe",
   "cancel": "Anuluj",
-
   "settings_opsec": "Tryb OPSEC",
   "settings_opsec_desc": "Tryb wzmocniony dla środowisk wysokiego ryzyka. Klucze przechowywane wyłącznie w pamięci RAM i usuwane przy zamknięciu.",
   "settings_opsec_enable": "Włącz tryb OPSEC",
@@ -280,9 +248,8 @@
   "settings_proxy_success": "Połączenie udane!",
   "settings_proxy_failed": "Połączenie nieudane: {error}",
   "settings_proxy_custom": "Niestandardowy",
-
-  "settings_about": "KeychainPGP {version} — Szyfrowanie PGP przez schowek dla komputerów stacjonarnych.",
   "settings_about_title": "O programie",
+  "settings_about": "KeychainPGP {version} — Szyfrowanie PGP przez schowek dla komputerów stacjonarnych.",
   "settings_portable_badge": "Tryb przenośny",
   "donate_button": "Wesprzyj ten projekt",
   "donate_title": "Wesprzyj KeychainPGP",
@@ -294,12 +261,10 @@
   "donate_eth": "Ethereum",
   "donate_xmr": "Monero",
   "donate_thanks": "Dziękujemy za wsparcie!",
-
   "unnamed": "(bez nazwy)",
   "none_value": "(brak)",
   "date_na": "N/D",
   "fingerprint_copy": "Kopiuj odcisk",
-
   "kbd_ctrl": "Ctrl",
   "kbd_shift": "Shift"
 }

--- a/crates/keychainpgp-ui/frontend/messages/pt-BR.json
+++ b/crates/keychainpgp-ui/frontend/messages/pt-BR.json
@@ -1,57 +1,46 @@
 {
   "$schema": "https://inlang.com/schema/inlang-message-format",
-
   "loading": "Carregando...",
   "ready": "Pronto",
-
   "nav_home": "Criptografar / Descriptografar",
   "nav_keys": "Chaves",
   "nav_settings": "Configurações",
-
   "home_title": "KeychainPGP",
   "home_tagline_clipboard": "Copie um texto e escolha uma ação abaixo.",
   "home_tagline_compose": "Digite sua mensagem e escolha uma ação abaixo.",
   "mode_clipboard": "Área de transferência",
   "mode_compose": "Redigir",
-
   "action_encrypt": "CRIPTOGRAFAR",
   "action_decrypt": "DESCRIPTOGRAFAR",
   "action_sign": "ASSINAR",
   "action_verify": "VERIFICAR",
-
   "clipboard_label": "Área de transferência",
   "clipboard_empty": "Sua área de transferência está vazia. Copie um texto para começar.",
   "clipboard_pgp_message": "Mensagem PGP",
   "clipboard_signed_message": "Mensagem assinada",
   "clipboard_refresh": "Atualizar área de transferência",
-
   "compose_label": "Redigir",
   "compose_placeholder": "Digite ou cole sua mensagem aqui...",
   "compose_clear": "Limpar",
-
   "encrypt_empty_clipboard": "A área de transferência está vazia. Copie um texto primeiro.",
   "encrypt_empty_compose": "O campo de texto está vazio. Digite uma mensagem primeiro.",
   "encrypt_no_keys": "Nenhuma chave disponível. Gere ou importe uma chave primeiro.",
-
   "decrypt_empty_clipboard": "A área de transferência está vazia. Copie uma mensagem criptografada primeiro.",
   "decrypt_empty_compose": "O campo de texto está vazio.",
   "decrypt_no_pgp": "Nenhuma mensagem PGP detectada.",
   "decrypt_in_progress": "Descriptografando...",
   "decrypt_success": "Descriptografado com sucesso.",
   "decrypt_wrong_key_hint": "Verifique se você importou a chave privada correta.",
-
   "sign_empty_clipboard": "A área de transferência está vazia. Copie um texto primeiro.",
   "sign_empty_compose": "O campo de texto está vazio.",
   "sign_no_key": "Nenhuma chave privada disponível. Gere ou importe uma primeiro.",
   "sign_in_progress": "Assinando...",
   "sign_success_compose": "Mensagem assinada.",
-
   "verify_empty_clipboard": "A área de transferência está vazia. Copie uma mensagem assinada primeiro.",
   "verify_empty_compose": "O campo de texto está vazio.",
   "verify_in_progress": "Verificando...",
   "verify_success": "Assinatura verificada.",
   "verify_failed": "Falha na verificação.",
-
   "verify_modal_title": "Verificação de assinatura",
   "verify_valid_verified": "Assinatura válida — Verificada",
   "verify_valid_verified_desc": "Esta mensagem foi assinada por uma chave verificada.",
@@ -61,7 +50,6 @@
   "verify_signer_label": "Signatário",
   "verify_email_label": "E-mail",
   "verify_fingerprint_label": "Impressão digital",
-
   "keys_title": "Gerenciador de chaves",
   "keys_generate": "Gerar",
   "keys_import_btn": "Importar",
@@ -74,7 +62,6 @@
   "keys_section_contacts": "Contatos",
   "keys_export_success": "Chave pública copiada para a área de transferência.",
   "keys_deleted": "Chave excluída.",
-
   "key_details_title": "Detalhes da chave",
   "key_details_btn": "Detalhes",
   "key_export_btn": "Exportar chave pública",
@@ -102,7 +89,6 @@
   "key_details_qr_btn": "Código QR",
   "key_details_not_found": "Chave não encontrada.",
   "key_trust_update_failed": "Falha ao atualizar confiança: {error}",
-
   "keygen_title": "Gerar novo par de chaves",
   "keygen_name_placeholder": "Nome",
   "keygen_email_placeholder": "E-mail",
@@ -112,7 +98,6 @@
   "keygen_submit": "Gerar",
   "keygen_loading": "Gerando...",
   "keygen_success": "Par de chaves gerado com sucesso!",
-
   "onboarding_title": "Bem-vindo ao KeychainPGP",
   "onboarding_subtitle": "Gere seu primeiro par de chaves para começar a usar a criptografia pela área de transferência.",
   "onboarding_name_placeholder": "Seu nome",
@@ -123,7 +108,6 @@
   "onboarding_import": "Importar chave existente",
   "onboarding_scan_qr": "Escanear código QR",
   "onboarding_sync": "Sincronizar de outro dispositivo",
-
   "recipient_title": "Selecionar destinatários",
   "recipient_search_placeholder": "Buscar chaves...",
   "recipient_no_keys": "Nenhuma chave disponível.",
@@ -136,7 +120,6 @@
   "recipient_encrypt_btn_other": "Criptografar para {count} destinatários",
   "recipient_encrypting": "Criptografando...",
   "recipient_encrypt_success": "Mensagem criptografada e copiada para a área de transferência.",
-
   "import_title": "Importar chave",
   "import_textarea_placeholder": "Cole uma chave PGP ASCII-armored ou arquivo de backup...",
   "import_or": "ou",
@@ -155,32 +138,26 @@
   "import_backup_success_one": "1 chave importada",
   "import_backup_success_other": "{count} chaves importadas",
   "import_backup_skipped": ", {count} já no chaveiro",
-
   "passphrase_title": "Digite a frase secreta",
   "passphrase_desc": "Esta chave é protegida por uma frase secreta. Digite-a para descriptografar.",
   "passphrase_placeholder": "Frase secreta",
   "passphrase_cancel": "Cancelar",
   "passphrase_submit": "Descriptografar",
-
   "decrypted_title": "Mensagem descriptografada",
   "decrypted_copy": "Copiar",
   "decrypted_copied": "Copiado",
   "decrypted_close": "Fechar",
-
   "error_title": "Erro",
   "error_fallback": "Ocorreu um erro inesperado.",
   "error_ok": "OK",
-
   "confirm_default_title": "Confirmar",
   "confirm_default_message": "Tem certeza?",
   "confirm_cancel": "Cancelar",
   "confirm_delete": "Excluir",
-
   "qr_title": "Exportar código QR",
   "qr_generating": "Gerando código QR...",
   "qr_desc": "Leia este código QR para importar a chave pública.",
   "qr_close": "Fechar",
-
   "discovery_title": "Descobrir chaves",
   "discovery_placeholder": "Endereço de e-mail ou nome...",
   "discovery_search": "Buscar",
@@ -190,11 +167,9 @@
   "discovery_import_hint": "Para importar uma chave descoberta, copie sua chave pública e use a função Importar na tela de Chaves.",
   "discovery_import_fail": "Não foi possível obter os dados da chave para importação.",
   "discovery_close": "Fechar",
-
   "trust_unknown": "Desconhecida",
   "trust_imported": "Importada",
   "trust_verified": "Verificada",
-
   "settings_title": "Configurações",
   "settings_appearance": "Aparência",
   "settings_theme_system": "Sistema",
@@ -202,13 +177,11 @@
   "settings_theme_dark": "Escuro",
   "settings_close_to_tray_label": "Fechar para a bandeja",
   "settings_close_to_tray_desc": "Manter o aplicativo na bandeja do sistema ao fechar a janela",
-
   "settings_clipboard": "Área de transferência",
   "settings_auto_clear_label": "Limpar área de transferência automaticamente",
   "settings_auto_clear_desc": "Limpar dados sensíveis da área de transferência após descriptografar",
   "settings_auto_clear_delay_label": "Tempo para limpeza automática",
   "settings_auto_clear_delay_desc": "Segundos antes de limpar a área de transferência",
-
   "settings_encryption": "Criptografia",
   "settings_encrypt_to_self_label": "Criptografar para si mesmo",
   "settings_encrypt_to_self_desc": "Sempre incluir sua própria chave como destinatário",
@@ -217,22 +190,18 @@
   "settings_self_keys_count_other": "{count} chaves selecionadas.",
   "settings_include_armor_label": "Incluir cabeçalhos armor",
   "settings_include_armor_desc": "Adicionar metadados de versão e comentário na saída PGP",
-
   "settings_security": "Segurança",
   "settings_passphrase_cache_label": "Duração do cache de frase secreta",
   "settings_passphrase_cache_desc": "Segundos para lembrar frases secretas (0 = desativado)",
   "settings_clear_cache": "Limpar frases secretas em cache",
   "settings_cache_cleared": "Cache de frases secretas limpo.",
   "settings_cache_clear_failed": "Falha ao limpar cache: {error}",
-
   "settings_key_discovery": "Descoberta de chaves",
   "settings_keyserver_label": "URL do servidor de chaves",
   "settings_keyserver_desc": "Usado para busca e envio de chaves",
-
   "settings_language": "Idioma",
   "settings_language_label": "Idioma de exibição",
   "settings_language_desc": "Escolha o idioma da interface",
-
   "settings_sync": "Sincronização de chaves",
   "settings_sync_desc": "Transfira suas chaves entre dispositivos com segurança.",
   "settings_sync_export": "Exportar chaves",
@@ -258,7 +227,6 @@
   "sync_error_no_passphrase": "Digite a frase secreta de sincronização exibida no dispositivo exportador.",
   "done": "Concluído",
   "cancel": "Cancelar",
-
   "settings_opsec": "Modo OPSEC",
   "settings_opsec_desc": "Modo reforçado para ambientes de alto risco. As chaves são armazenadas apenas na RAM e apagadas ao sair.",
   "settings_opsec_enable": "Ativar modo OPSEC",
@@ -280,9 +248,8 @@
   "settings_proxy_success": "Conexão bem-sucedida!",
   "settings_proxy_failed": "Falha na conexão: {error}",
   "settings_proxy_custom": "Personalizado",
-
-  "settings_about": "KeychainPGP {version} — Criptografia PGP para desktop focada na area de transferência.",
   "settings_about_title": "Sobre",
+  "settings_about": "KeychainPGP {version} — Criptografia PGP para desktop focada na area de transferência.",
   "settings_portable_badge": "Modo portátil",
   "donate_button": "Apoie este projeto",
   "donate_title": "Apoie o KeychainPGP",
@@ -294,12 +261,10 @@
   "donate_eth": "Ethereum",
   "donate_xmr": "Monero",
   "donate_thanks": "Obrigado pelo seu apoio!",
-
   "unnamed": "(sem nome)",
   "none_value": "(nenhum)",
   "date_na": "N/D",
   "fingerprint_copy": "Copiar impressão digital",
-
   "kbd_ctrl": "Ctrl",
   "kbd_shift": "Shift"
 }

--- a/crates/keychainpgp-ui/frontend/messages/pt-PT.json
+++ b/crates/keychainpgp-ui/frontend/messages/pt-PT.json
@@ -1,57 +1,46 @@
 {
   "$schema": "https://inlang.com/schema/inlang-message-format",
-
   "loading": "A carregar...",
   "ready": "Pronto",
-
   "nav_home": "Encriptar / Desencriptar",
   "nav_keys": "Chaves",
   "nav_settings": "Definições",
-
   "home_title": "KeychainPGP",
   "home_tagline_clipboard": "Copie texto e escolha uma ação abaixo.",
   "home_tagline_compose": "Escreva a sua mensagem e escolha uma ação abaixo.",
   "mode_clipboard": "Área de transferência",
   "mode_compose": "Compor",
-
   "action_encrypt": "ENCRIPTAR",
   "action_decrypt": "DESENCRIPTAR",
   "action_sign": "ASSINAR",
   "action_verify": "VERIFICAR",
-
   "clipboard_label": "Área de transferência",
   "clipboard_empty": "A sua área de transferência está vazia. Copie texto para começar.",
   "clipboard_pgp_message": "Mensagem PGP",
   "clipboard_signed_message": "Mensagem assinada",
   "clipboard_refresh": "Atualizar área de transferência",
-
   "compose_label": "Compor",
   "compose_placeholder": "Escreva ou cole a sua mensagem aqui...",
   "compose_clear": "Limpar",
-
   "encrypt_empty_clipboard": "A área de transferência está vazia. Copie texto primeiro.",
   "encrypt_empty_compose": "O campo de texto está vazio. Escreva uma mensagem primeiro.",
   "encrypt_no_keys": "Nenhuma chave disponível. Gere ou importe uma chave primeiro.",
-
   "decrypt_empty_clipboard": "A área de transferência está vazia. Copie uma mensagem encriptada primeiro.",
   "decrypt_empty_compose": "O campo de texto está vazio.",
   "decrypt_no_pgp": "Nenhuma mensagem PGP detetada.",
   "decrypt_in_progress": "A desencriptar...",
   "decrypt_success": "Desencriptado com sucesso.",
   "decrypt_wrong_key_hint": "Certifique-se de que importou a chave privada correta.",
-
   "sign_empty_clipboard": "A área de transferência está vazia. Copie texto primeiro.",
   "sign_empty_compose": "O campo de texto está vazio.",
   "sign_no_key": "Nenhuma chave privada disponível. Gere ou importe uma primeiro.",
   "sign_in_progress": "A assinar...",
   "sign_success_compose": "Mensagem assinada.",
-
   "verify_empty_clipboard": "A área de transferência está vazia. Copie uma mensagem assinada primeiro.",
   "verify_empty_compose": "O campo de texto está vazio.",
   "verify_in_progress": "A verificar...",
   "verify_success": "Assinatura verificada.",
   "verify_failed": "Falha na verificação.",
-
   "verify_modal_title": "Verificação de assinatura",
   "verify_valid_verified": "Assinatura válida — Verificada",
   "verify_valid_verified_desc": "Esta mensagem foi assinada por uma chave verificada.",
@@ -61,7 +50,6 @@
   "verify_signer_label": "Signatário",
   "verify_email_label": "E-mail",
   "verify_fingerprint_label": "Impressão digital",
-
   "keys_title": "Gestor de chaves",
   "keys_generate": "Gerar",
   "keys_import_btn": "Importar",
@@ -74,7 +62,6 @@
   "keys_section_contacts": "Contactos",
   "keys_export_success": "Chave pública copiada para a área de transferência.",
   "keys_deleted": "Chave eliminada.",
-
   "key_details_title": "Detalhes da chave",
   "key_details_btn": "Detalhes",
   "key_export_btn": "Exportar chave pública",
@@ -102,7 +89,6 @@
   "key_details_qr_btn": "Código QR",
   "key_details_not_found": "Chave não encontrada.",
   "key_trust_update_failed": "Falha ao atualizar confiança: {error}",
-
   "keygen_title": "Gerar novo par de chaves",
   "keygen_name_placeholder": "Nome",
   "keygen_email_placeholder": "E-mail",
@@ -112,7 +98,6 @@
   "keygen_submit": "Gerar",
   "keygen_loading": "A gerar...",
   "keygen_success": "Par de chaves gerado com sucesso!",
-
   "onboarding_title": "Bem-vindo ao KeychainPGP",
   "onboarding_subtitle": "Gere o seu primeiro par de chaves para começar a utilizar a encriptação pela área de transferência.",
   "onboarding_name_placeholder": "O seu nome",
@@ -123,7 +108,6 @@
   "onboarding_import": "Importar chave existente",
   "onboarding_scan_qr": "Digitalizar código QR",
   "onboarding_sync": "Sincronizar a partir de outro dispositivo",
-
   "recipient_title": "Selecionar destinatários",
   "recipient_search_placeholder": "Pesquisar chaves...",
   "recipient_no_keys": "Nenhuma chave disponível.",
@@ -136,7 +120,6 @@
   "recipient_encrypt_btn_other": "Encriptar para {count} destinatários",
   "recipient_encrypting": "A encriptar...",
   "recipient_encrypt_success": "Mensagem encriptada e copiada para a área de transferência.",
-
   "import_title": "Importar chave",
   "import_textarea_placeholder": "Cole uma chave PGP ASCII-armored ou ficheiro de cópia de segurança...",
   "import_or": "ou",
@@ -155,32 +138,26 @@
   "import_backup_success_one": "1 chave importada",
   "import_backup_success_other": "{count} chaves importadas",
   "import_backup_skipped": ", {count} já no porta-chaves",
-
   "passphrase_title": "Introduza a frase-passe",
   "passphrase_desc": "Esta chave está protegida com uma frase-passe. Introduza-a para desencriptar.",
   "passphrase_placeholder": "Frase-passe",
   "passphrase_cancel": "Cancelar",
   "passphrase_submit": "Desencriptar",
-
   "decrypted_title": "Mensagem desencriptada",
   "decrypted_copy": "Copiar",
   "decrypted_copied": "Copiado",
   "decrypted_close": "Fechar",
-
   "error_title": "Erro",
   "error_fallback": "Ocorreu um erro inesperado.",
   "error_ok": "OK",
-
   "confirm_default_title": "Confirmar",
   "confirm_default_message": "Tem a certeza?",
   "confirm_cancel": "Cancelar",
   "confirm_delete": "Eliminar",
-
   "qr_title": "Exportar código QR",
   "qr_generating": "A gerar código QR...",
   "qr_desc": "Leia este código QR para importar a chave pública.",
   "qr_close": "Fechar",
-
   "discovery_title": "Descobrir chaves",
   "discovery_placeholder": "Endereço de e-mail ou nome...",
   "discovery_search": "Pesquisar",
@@ -190,11 +167,9 @@
   "discovery_import_hint": "Para importar uma chave descoberta, copie a sua chave pública e utilize a função Importar no ecrã de Chaves.",
   "discovery_import_fail": "Não foi possível obter os dados da chave para importação.",
   "discovery_close": "Fechar",
-
   "trust_unknown": "Desconhecida",
   "trust_imported": "Importada",
   "trust_verified": "Verificada",
-
   "settings_title": "Definições",
   "settings_appearance": "Aparência",
   "settings_theme_system": "Sistema",
@@ -202,13 +177,11 @@
   "settings_theme_dark": "Escuro",
   "settings_close_to_tray_label": "Fechar para a bandeja",
   "settings_close_to_tray_desc": "Manter a aplicação na bandeja do sistema ao fechar a janela",
-
   "settings_clipboard": "Área de transferência",
   "settings_auto_clear_label": "Limpar área de transferência automaticamente",
   "settings_auto_clear_desc": "Limpar dados sensíveis da área de transferência após desencriptar",
   "settings_auto_clear_delay_label": "Tempo para limpeza automática",
   "settings_auto_clear_delay_desc": "Segundos antes de limpar a área de transferência",
-
   "settings_encryption": "Encriptação",
   "settings_encrypt_to_self_label": "Encriptar para si próprio",
   "settings_encrypt_to_self_desc": "Incluir sempre a sua própria chave como destinatário",
@@ -217,22 +190,18 @@
   "settings_self_keys_count_other": "{count} chaves selecionadas.",
   "settings_include_armor_label": "Incluir cabeçalhos armor",
   "settings_include_armor_desc": "Adicionar metadados de versão e comentário na saída PGP",
-
   "settings_security": "Segurança",
   "settings_passphrase_cache_label": "Duração da cache de frase-passe",
   "settings_passphrase_cache_desc": "Segundos para memorizar frases-passe (0 = desativado)",
   "settings_clear_cache": "Limpar frases-passe em cache",
   "settings_cache_cleared": "Cache de frases-passe limpa.",
   "settings_cache_clear_failed": "Falha ao limpar cache: {error}",
-
   "settings_key_discovery": "Descoberta de chaves",
   "settings_keyserver_label": "URL do servidor de chaves",
   "settings_keyserver_desc": "Utilizado para pesquisa e envio de chaves",
-
   "settings_language": "Idioma",
   "settings_language_label": "Idioma de apresentação",
   "settings_language_desc": "Escolha o idioma da interface",
-
   "settings_sync": "Sincronização de chaves",
   "settings_sync_desc": "Transfira as suas chaves entre dispositivos de forma segura.",
   "settings_sync_export": "Exportar chaves",
@@ -258,7 +227,6 @@
   "sync_error_no_passphrase": "Introduza a frase-passe de sincronização apresentada no dispositivo exportador.",
   "done": "Concluído",
   "cancel": "Cancelar",
-
   "settings_opsec": "Modo OPSEC",
   "settings_opsec_desc": "Modo reforçado para ambientes de alto risco. As chaves são armazenadas apenas na RAM e eliminadas ao sair.",
   "settings_opsec_enable": "Ativar modo OPSEC",
@@ -280,9 +248,8 @@
   "settings_proxy_success": "Ligação bem-sucedida!",
   "settings_proxy_failed": "Falha na ligação: {error}",
   "settings_proxy_custom": "Personalizado",
-
-  "settings_about": "KeychainPGP {version} — Encriptação PGP para ambiente de trabalho centrada na área de transferência.",
   "settings_about_title": "Sobre",
+  "settings_about": "KeychainPGP {version} — Encriptação PGP para ambiente de trabalho centrada na área de transferência.",
   "settings_portable_badge": "Modo portátil",
   "donate_button": "Apoie este projeto",
   "donate_title": "Apoie o KeychainPGP",
@@ -294,12 +261,10 @@
   "donate_eth": "Ethereum",
   "donate_xmr": "Monero",
   "donate_thanks": "Obrigado pelo seu apoio!",
-
   "unnamed": "(sem nome)",
   "none_value": "(nenhum)",
   "date_na": "N/D",
   "fingerprint_copy": "Copiar impressão digital",
-
   "kbd_ctrl": "Ctrl",
   "kbd_shift": "Shift"
 }

--- a/crates/keychainpgp-ui/frontend/messages/ru.json
+++ b/crates/keychainpgp-ui/frontend/messages/ru.json
@@ -1,57 +1,46 @@
 {
   "$schema": "https://inlang.com/schema/inlang-message-format",
-
   "loading": "Загрузка...",
   "ready": "Готово",
-
   "nav_home": "Шифрование / Расшифровка",
   "nav_keys": "Ключи",
   "nav_settings": "Настройки",
-
   "home_title": "KeychainPGP",
   "home_tagline_clipboard": "Скопируйте текст, затем выберите действие ниже.",
   "home_tagline_compose": "Введите сообщение, затем выберите действие ниже.",
   "mode_clipboard": "Буфер обмена",
   "mode_compose": "Редактор",
-
   "action_encrypt": "ЗАШИФРОВАТЬ",
   "action_decrypt": "РАСШИФРОВАТЬ",
   "action_sign": "ПОДПИСАТЬ",
   "action_verify": "ПРОВЕРИТЬ",
-
   "clipboard_label": "Буфер обмена",
   "clipboard_empty": "Буфер обмена пуст. Скопируйте текст, чтобы начать.",
   "clipboard_pgp_message": "Сообщение PGP",
   "clipboard_signed_message": "Подписанное сообщение",
   "clipboard_refresh": "Обновить буфер обмена",
-
   "compose_label": "Редактор",
   "compose_placeholder": "Введите или вставьте сообщение...",
   "compose_clear": "Очистить",
-
   "encrypt_empty_clipboard": "Буфер обмена пуст. Сначала скопируйте текст.",
   "encrypt_empty_compose": "Поле ввода пусто. Сначала введите сообщение.",
   "encrypt_no_keys": "Нет доступных ключей. Сначала создайте или импортируйте ключ.",
-
   "decrypt_empty_clipboard": "Буфер обмена пуст. Сначала скопируйте зашифрованное сообщение.",
   "decrypt_empty_compose": "Поле ввода пусто.",
   "decrypt_no_pgp": "Сообщение PGP не обнаружено.",
   "decrypt_in_progress": "Расшифровка...",
   "decrypt_success": "Успешно расшифровано.",
   "decrypt_wrong_key_hint": "Убедитесь, что у вас импортирован правильный закрытый ключ.",
-
   "sign_empty_clipboard": "Буфер обмена пуст. Сначала скопируйте текст.",
   "sign_empty_compose": "Поле ввода пусто.",
   "sign_no_key": "Нет закрытого ключа. Сначала создайте или импортируйте его.",
   "sign_in_progress": "Подписание...",
   "sign_success_compose": "Сообщение подписано.",
-
   "verify_empty_clipboard": "Буфер обмена пуст. Сначала скопируйте подписанное сообщение.",
   "verify_empty_compose": "Поле ввода пусто.",
   "verify_in_progress": "Проверка...",
   "verify_success": "Подпись подтверждена.",
   "verify_failed": "Проверка не пройдена.",
-
   "verify_modal_title": "Проверка подписи",
   "verify_valid_verified": "Действительная подпись — проверенный ключ",
   "verify_valid_verified_desc": "Это сообщение подписано проверенным ключом.",
@@ -61,7 +50,6 @@
   "verify_signer_label": "Подписант",
   "verify_email_label": "Эл. почта",
   "verify_fingerprint_label": "Отпечаток",
-
   "keys_title": "Управление ключами",
   "keys_generate": "Создать",
   "keys_import_btn": "Импорт",
@@ -74,7 +62,6 @@
   "keys_section_contacts": "Контакты",
   "keys_export_success": "Открытый ключ скопирован в буфер обмена.",
   "keys_deleted": "Ключ удалён.",
-
   "key_details_title": "Сведения о ключе",
   "key_details_btn": "Подробнее",
   "key_export_btn": "Экспортировать открытый ключ",
@@ -102,7 +89,6 @@
   "key_details_qr_btn": "QR-код",
   "key_details_not_found": "Ключ не найден.",
   "key_trust_update_failed": "Не удалось обновить доверие: {error}",
-
   "keygen_title": "Создание новой пары ключей",
   "keygen_name_placeholder": "Имя",
   "keygen_email_placeholder": "Эл. почта",
@@ -112,7 +98,6 @@
   "keygen_submit": "Создать",
   "keygen_loading": "Создание...",
   "keygen_success": "Пара ключей успешно создана!",
-
   "onboarding_title": "Добро пожаловать в KeychainPGP",
   "onboarding_subtitle": "Создайте свою первую пару ключей, чтобы начать шифрование через буфер обмена.",
   "onboarding_name_placeholder": "Ваше имя",
@@ -123,7 +108,6 @@
   "onboarding_import": "Импортировать существующий ключ",
   "onboarding_scan_qr": "Сканировать QR-код",
   "onboarding_sync": "Синхронизация с другого устройства",
-
   "recipient_title": "Выбор получателей",
   "recipient_search_placeholder": "Поиск ключей...",
   "recipient_no_keys": "Нет доступных ключей.",
@@ -136,7 +120,6 @@
   "recipient_encrypt_btn_other": "Зашифровать для {count} получателей",
   "recipient_encrypting": "Шифрование...",
   "recipient_encrypt_success": "Сообщение зашифровано и скопировано в буфер обмена.",
-
   "import_title": "Импорт ключа",
   "import_textarea_placeholder": "Вставьте PGP-ключ в формате ASCII-armored или файл резервной копии...",
   "import_or": "или",
@@ -155,32 +138,26 @@
   "import_backup_success_one": "Импортирован 1 ключ",
   "import_backup_success_other": "Импортировано ключей: {count}",
   "import_backup_skipped": ", {count} уже в связке ключей",
-
   "passphrase_title": "Введите парольную фразу",
   "passphrase_desc": "Этот ключ защищён парольной фразой. Введите её для расшифровки.",
   "passphrase_placeholder": "Парольная фраза",
   "passphrase_cancel": "Отмена",
   "passphrase_submit": "Расшифровать",
-
   "decrypted_title": "Расшифрованное сообщение",
   "decrypted_copy": "Копировать",
   "decrypted_copied": "Скопировано",
   "decrypted_close": "Закрыть",
-
   "error_title": "Ошибка",
   "error_fallback": "Произошла непредвиденная ошибка.",
   "error_ok": "ОК",
-
   "confirm_default_title": "Подтверждение",
   "confirm_default_message": "Вы уверены?",
   "confirm_cancel": "Отмена",
   "confirm_delete": "Удалить",
-
   "qr_title": "Экспорт QR-кода",
   "qr_generating": "Создание QR-кода...",
   "qr_desc": "Отсканируйте этот QR-код, чтобы импортировать открытый ключ.",
   "qr_close": "Закрыть",
-
   "discovery_title": "Поиск ключей",
   "discovery_placeholder": "Адрес электронной почты или имя...",
   "discovery_search": "Найти",
@@ -190,11 +167,9 @@
   "discovery_import_hint": "Чтобы импортировать найденный ключ, скопируйте его открытый ключ и используйте функцию импорта на вкладке «Ключи».",
   "discovery_import_fail": "Не удалось получить данные ключа для импорта.",
   "discovery_close": "Закрыть",
-
   "trust_unknown": "Неизвестно",
   "trust_imported": "Импортирован",
   "trust_verified": "Проверен",
-
   "settings_title": "Настройки",
   "settings_appearance": "Оформление",
   "settings_theme_system": "Системная",
@@ -202,13 +177,11 @@
   "settings_theme_dark": "Тёмная",
   "settings_close_to_tray_label": "Сворачивать в трей",
   "settings_close_to_tray_desc": "Оставлять приложение в области уведомлений при закрытии окна",
-
   "settings_clipboard": "Буфер обмена",
   "settings_auto_clear_label": "Автоочистка буфера обмена",
   "settings_auto_clear_desc": "Очищать конфиденциальные данные из буфера обмена после расшифровки",
   "settings_auto_clear_delay_label": "Задержка автоочистки",
   "settings_auto_clear_delay_desc": "Секунды до очистки буфера обмена",
-
   "settings_encryption": "Шифрование",
   "settings_encrypt_to_self_label": "Шифровать для себя",
   "settings_encrypt_to_self_desc": "Всегда включать ваш ключ в список получателей",
@@ -217,22 +190,18 @@
   "settings_self_keys_count_other": "Выбрано ключей: {count}.",
   "settings_include_armor_label": "Включать заголовки ASCII-armored",
   "settings_include_armor_desc": "Добавлять метаданные Version и Comment в вывод PGP",
-
   "settings_security": "Безопасность",
   "settings_passphrase_cache_label": "Время кэширования парольной фразы",
   "settings_passphrase_cache_desc": "Секунды хранения парольных фраз (0 = отключено)",
   "settings_clear_cache": "Очистить кэш парольных фраз",
   "settings_cache_cleared": "Кэш парольных фраз очищен.",
   "settings_cache_clear_failed": "Не удалось очистить кэш: {error}",
-
   "settings_key_discovery": "Поиск ключей",
   "settings_keyserver_label": "URL сервера ключей",
   "settings_keyserver_desc": "Используется для поиска и загрузки ключей",
-
   "settings_language": "Язык",
   "settings_language_label": "Язык интерфейса",
   "settings_language_desc": "Выберите язык интерфейса",
-
   "settings_sync": "Синхронизация ключей",
   "settings_sync_desc": "Безопасная передача ключей между устройствами.",
   "settings_sync_export": "Экспортировать ключи",
@@ -258,7 +227,6 @@
   "sync_error_no_passphrase": "Введите парольную фразу синхронизации, показанную на экспортирующем устройстве.",
   "done": "Готово",
   "cancel": "Отмена",
-
   "settings_opsec": "Режим OPSEC",
   "settings_opsec_desc": "Усиленный режим для высокорисковых сред. Ключи хранятся только в оперативной памяти и уничтожаются при выходе.",
   "settings_opsec_enable": "Включить режим OPSEC",
@@ -280,9 +248,8 @@
   "settings_proxy_success": "Соединение успешно!",
   "settings_proxy_failed": "Ошибка соединения: {error}",
   "settings_proxy_custom": "Другой",
-
-  "settings_about": "KeychainPGP {version} — PGP-шифрование через буфер обмена для настольных систем.",
   "settings_about_title": "О программе",
+  "settings_about": "KeychainPGP {version} — PGP-шифрование через буфер обмена для настольных систем.",
   "settings_portable_badge": "Портативный режим",
   "donate_button": "Поддержать проект",
   "donate_title": "Поддержите KeychainPGP",
@@ -294,12 +261,10 @@
   "donate_eth": "Ethereum",
   "donate_xmr": "Monero",
   "donate_thanks": "Спасибо за вашу поддержку!",
-
   "unnamed": "(без имени)",
   "none_value": "(нет)",
   "date_na": "Н/Д",
   "fingerprint_copy": "Копировать отпечаток",
-
   "kbd_ctrl": "Ctrl",
   "kbd_shift": "Shift"
 }

--- a/crates/keychainpgp-ui/frontend/messages/th.json
+++ b/crates/keychainpgp-ui/frontend/messages/th.json
@@ -1,57 +1,46 @@
 {
   "$schema": "https://inlang.com/schema/inlang-message-format",
-
   "loading": "กำลังโหลด...",
   "ready": "พร้อม",
-
   "nav_home": "เข้ารหัส / ถอดรหัส",
   "nav_keys": "คีย์",
   "nav_settings": "การตั้งค่า",
-
   "home_title": "KeychainPGP",
   "home_tagline_clipboard": "คัดลอกข้อความ จากนั้นเลือกการดำเนินการด้านล่าง",
   "home_tagline_compose": "พิมพ์ข้อความของคุณ จากนั้นเลือกการดำเนินการด้านล่าง",
   "mode_clipboard": "คลิปบอร์ด",
   "mode_compose": "เขียน",
-
   "action_encrypt": "เข้ารหัส",
   "action_decrypt": "ถอดรหัส",
   "action_sign": "ลงลายเซ็น",
   "action_verify": "ตรวจสอบ",
-
   "clipboard_label": "คลิปบอร์ด",
   "clipboard_empty": "คลิปบอร์ดของคุณว่างเปล่า คัดลอกข้อความเพื่อเริ่มต้น",
   "clipboard_pgp_message": "ข้อความ PGP",
   "clipboard_signed_message": "ข้อความที่ลงลายเซ็น",
   "clipboard_refresh": "รีเฟรชคลิปบอร์ด",
-
   "compose_label": "เขียน",
   "compose_placeholder": "พิมพ์หรือวางข้อความของคุณที่นี่...",
   "compose_clear": "ล้าง",
-
   "encrypt_empty_clipboard": "คลิปบอร์ดว่างเปล่า กรุณาคัดลอกข้อความก่อน",
   "encrypt_empty_compose": "ช่องเขียนว่างเปล่า กรุณาพิมพ์ข้อความก่อน",
   "encrypt_no_keys": "ไม่มีคีย์ที่พร้อมใช้งาน กรุณาสร้างหรือนำเข้าคีย์ก่อน",
-
   "decrypt_empty_clipboard": "คลิปบอร์ดว่างเปล่า กรุณาคัดลอกข้อความที่เข้ารหัสก่อน",
   "decrypt_empty_compose": "ช่องเขียนว่างเปล่า",
   "decrypt_no_pgp": "ไม่พบข้อความ PGP",
   "decrypt_in_progress": "กำลังถอดรหัส...",
   "decrypt_success": "ถอดรหัสสำเร็จ",
   "decrypt_wrong_key_hint": "ตรวจสอบให้แน่ใจว่าคุณนำเข้าคีย์ส่วนตัวที่ถูกต้องแล้ว",
-
   "sign_empty_clipboard": "คลิปบอร์ดว่างเปล่า กรุณาคัดลอกข้อความก่อน",
   "sign_empty_compose": "ช่องเขียนว่างเปล่า",
   "sign_no_key": "ไม่มีคีย์ส่วนตัวที่พร้อมใช้งาน กรุณาสร้างหรือนำเข้าคีย์ก่อน",
   "sign_in_progress": "กำลังลงลายเซ็น...",
   "sign_success_compose": "ลงลายเซ็นข้อความแล้ว",
-
   "verify_empty_clipboard": "คลิปบอร์ดว่างเปล่า กรุณาคัดลอกข้อความที่ลงลายเซ็นก่อน",
   "verify_empty_compose": "ช่องเขียนว่างเปล่า",
   "verify_in_progress": "กำลังตรวจสอบ...",
   "verify_success": "ตรวจสอบลายเซ็นสำเร็จ",
   "verify_failed": "การตรวจสอบล้มเหลว",
-
   "verify_modal_title": "การตรวจสอบลายเซ็น",
   "verify_valid_verified": "ลายเซ็นถูกต้อง — ยืนยันแล้ว",
   "verify_valid_verified_desc": "ข้อความนี้ลงลายเซ็นโดยคีย์ที่ยืนยันแล้ว",
@@ -61,7 +50,6 @@
   "verify_signer_label": "ผู้ลงลายเซ็น",
   "verify_email_label": "อีเมล",
   "verify_fingerprint_label": "ลายนิ้วมือ",
-
   "keys_title": "จัดการคีย์",
   "keys_generate": "สร้าง",
   "keys_import_btn": "นำเข้า",
@@ -74,7 +62,6 @@
   "keys_section_contacts": "ผู้ติดต่อ",
   "keys_export_success": "คัดลอกคีย์สาธารณะไปยังคลิปบอร์ดแล้ว",
   "keys_deleted": "ลบคีย์แล้ว",
-
   "key_details_title": "รายละเอียดคีย์",
   "key_details_btn": "รายละเอียด",
   "key_export_btn": "ส่งออกคีย์สาธารณะ",
@@ -102,7 +89,6 @@
   "key_details_qr_btn": "QR Code",
   "key_details_not_found": "ไม่พบคีย์",
   "key_trust_update_failed": "อัปเดตความเชื่อถือล้มเหลว: {error}",
-
   "keygen_title": "สร้างคู่คีย์ใหม่",
   "keygen_name_placeholder": "ชื่อ",
   "keygen_email_placeholder": "อีเมล",
@@ -112,7 +98,6 @@
   "keygen_submit": "สร้าง",
   "keygen_loading": "กำลังสร้าง...",
   "keygen_success": "สร้างคู่คีย์สำเร็จแล้ว!",
-
   "onboarding_title": "ยินดีต้อนรับสู่ KeychainPGP",
   "onboarding_subtitle": "สร้างคู่คีย์แรกของคุณเพื่อเริ่มต้นการเข้ารหัสคลิปบอร์ด",
   "onboarding_name_placeholder": "ชื่อของคุณ",
@@ -123,7 +108,6 @@
   "onboarding_import": "นำเข้าคีย์ที่มีอยู่",
   "onboarding_scan_qr": "สแกน QR โค้ด",
   "onboarding_sync": "ซิงค์จากอุปกรณ์อื่น",
-
   "recipient_title": "เลือกผู้รับ",
   "recipient_search_placeholder": "ค้นหาคีย์...",
   "recipient_no_keys": "ไม่มีคีย์ที่พร้อมใช้งาน",
@@ -136,7 +120,6 @@
   "recipient_encrypt_btn_other": "เข้ารหัสสำหรับผู้รับ {count} คน",
   "recipient_encrypting": "กำลังเข้ารหัส...",
   "recipient_encrypt_success": "เข้ารหัสข้อความและคัดลอกไปยังคลิปบอร์ดแล้ว",
-
   "import_title": "นำเข้าคีย์",
   "import_textarea_placeholder": "วางคีย์ PGP แบบ ASCII-armored หรือไฟล์สำรอง...",
   "import_or": "หรือ",
@@ -155,32 +138,26 @@
   "import_backup_success_one": "นำเข้า 1 คีย์แล้ว",
   "import_backup_success_other": "นำเข้า {count} คีย์แล้ว",
   "import_backup_skipped": ", {count} อยู่ในชุดคีย์แล้ว",
-
   "passphrase_title": "ป้อนวลีรหัสผ่าน",
   "passphrase_desc": "คีย์นี้ได้รับการป้องกันด้วยวลีรหัสผ่าน ป้อนเพื่อถอดรหัส",
   "passphrase_placeholder": "วลีรหัสผ่าน",
   "passphrase_cancel": "ยกเลิก",
   "passphrase_submit": "ถอดรหัส",
-
   "decrypted_title": "ข้อความที่ถอดรหัสแล้ว",
   "decrypted_copy": "คัดลอก",
   "decrypted_copied": "คัดลอกแล้ว",
   "decrypted_close": "ปิด",
-
   "error_title": "ข้อผิดพลาด",
   "error_fallback": "เกิดข้อผิดพลาดที่ไม่คาดคิด",
   "error_ok": "ตกลง",
-
   "confirm_default_title": "ยืนยัน",
   "confirm_default_message": "คุณแน่ใจหรือไม่?",
   "confirm_cancel": "ยกเลิก",
   "confirm_delete": "ลบ",
-
   "qr_title": "ส่งออก QR Code",
   "qr_generating": "กำลังสร้าง QR Code...",
   "qr_desc": "สแกน QR Code นี้เพื่อนำเข้าคีย์สาธารณะ",
   "qr_close": "ปิด",
-
   "discovery_title": "ค้นหาคีย์",
   "discovery_placeholder": "ที่อยู่อีเมลหรือชื่อ...",
   "discovery_search": "ค้นหา",
@@ -190,11 +167,9 @@
   "discovery_import_hint": "หากต้องการนำเข้าคีย์ที่ค้นพบ ให้คัดลอกคีย์สาธารณะแล้วใช้ฟังก์ชันนำเข้าในหน้าจัดการคีย์",
   "discovery_import_fail": "ไม่สามารถดึงข้อมูลคีย์สำหรับการนำเข้าได้",
   "discovery_close": "ปิด",
-
   "trust_unknown": "ไม่ทราบ",
   "trust_imported": "นำเข้าแล้ว",
   "trust_verified": "ยืนยันแล้ว",
-
   "settings_title": "การตั้งค่า",
   "settings_appearance": "รูปลักษณ์",
   "settings_theme_system": "ระบบ",
@@ -202,13 +177,11 @@
   "settings_theme_dark": "มืด",
   "settings_close_to_tray_label": "ปิดไปที่ถาดระบบ",
   "settings_close_to_tray_desc": "เปิดแอปต่อในถาดระบบเมื่อปิดหน้าต่าง",
-
   "settings_clipboard": "คลิปบอร์ด",
   "settings_auto_clear_label": "ล้างคลิปบอร์ดอัตโนมัติ",
   "settings_auto_clear_desc": "ล้างข้อมูลที่ละเอียดอ่อนจากคลิปบอร์ดหลังการถอดรหัส",
   "settings_auto_clear_delay_label": "การหน่วงเวลาล้างอัตโนมัติ",
   "settings_auto_clear_delay_desc": "จำนวนวินาทีก่อนล้างคลิปบอร์ด",
-
   "settings_encryption": "การเข้ารหัส",
   "settings_encrypt_to_self_label": "เข้ารหัสถึงตัวเอง",
   "settings_encrypt_to_self_desc": "รวมคีย์ของคุณเป็นผู้รับเสมอ",
@@ -217,22 +190,18 @@
   "settings_self_keys_count_other": "เลือก {count} คีย์แล้ว",
   "settings_include_armor_label": "รวมส่วนหัว armor",
   "settings_include_armor_desc": "เพิ่มข้อมูลเมตาเวอร์ชันและความคิดเห็นในผลลัพธ์ PGP",
-
   "settings_security": "ความปลอดภัย",
   "settings_passphrase_cache_label": "ระยะเวลาแคชวลีรหัสผ่าน",
   "settings_passphrase_cache_desc": "จำนวนวินาทีที่จดจำวลีรหัสผ่าน (0 = ปิดใช้งาน)",
   "settings_clear_cache": "ล้างวลีรหัสผ่านที่แคชไว้",
   "settings_cache_cleared": "ล้างแคชวลีรหัสผ่านแล้ว",
   "settings_cache_clear_failed": "ล้างแคชล้มเหลว: {error}",
-
   "settings_key_discovery": "การค้นหาคีย์",
   "settings_keyserver_label": "URL เซิร์ฟเวอร์คีย์",
   "settings_keyserver_desc": "ใช้สำหรับค้นหาและอัปโหลดคีย์",
-
   "settings_language": "ภาษา",
   "settings_language_label": "ภาษาที่แสดง",
   "settings_language_desc": "เลือกภาษาสำหรับอินเทอร์เฟซ",
-
   "settings_sync": "ซิงค์คีย์",
   "settings_sync_desc": "โอนคีย์ของคุณระหว่างอุปกรณ์อย่างปลอดภัย",
   "settings_sync_export": "ส่งออกคีย์",
@@ -258,7 +227,6 @@
   "sync_error_no_passphrase": "ป้อนวลีรหัสผ่านซิงค์ที่แสดงบนอุปกรณ์ที่ส่งออก",
   "done": "เสร็จสิ้น",
   "cancel": "ยกเลิก",
-
   "settings_opsec": "โหมด OPSEC",
   "settings_opsec_desc": "โหมดเสริมความปลอดภัยสำหรับสภาพแวดล้อมที่มีความเสี่ยงสูง คีย์จะถูกเก็บใน RAM เท่านั้นและถูกลบเมื่อออกจากโปรแกรม",
   "settings_opsec_enable": "เปิดใช้งานโหมด OPSEC",
@@ -280,9 +248,8 @@
   "settings_proxy_success": "เชื่อมต่อสำเร็จ!",
   "settings_proxy_failed": "เชื่อมต่อล้มเหลว: {error}",
   "settings_proxy_custom": "กำหนดเอง",
-
-  "settings_about": "KeychainPGP {version} — การเข้ารหัส PGP แบบคลิปบอร์ดเป็นหลักสำหรับเดสก์ท็อป",
   "settings_about_title": "เกี่ยวกับ",
+  "settings_about": "KeychainPGP {version} — การเข้ารหัส PGP แบบคลิปบอร์ดเป็นหลักสำหรับเดสก์ท็อป",
   "settings_portable_badge": "โหมดพกพา",
   "donate_button": "สนับสนุนโครงการนี้",
   "donate_title": "สนับสนุน KeychainPGP",
@@ -294,12 +261,10 @@
   "donate_eth": "Ethereum",
   "donate_xmr": "Monero",
   "donate_thanks": "ขอบคุณสำหรับการสนับสนุนของคุณ!",
-
   "unnamed": "(ไม่มีชื่อ)",
   "none_value": "(ไม่มี)",
   "date_na": "ไม่มีข้อมูล",
   "fingerprint_copy": "คัดลอกลายนิ้วมือ",
-
   "kbd_ctrl": "Ctrl",
   "kbd_shift": "Shift"
 }

--- a/crates/keychainpgp-ui/frontend/messages/tr.json
+++ b/crates/keychainpgp-ui/frontend/messages/tr.json
@@ -1,57 +1,46 @@
 {
   "$schema": "https://inlang.com/schema/inlang-message-format",
-
   "loading": "Yükleniyor...",
   "ready": "Hazır",
-
   "nav_home": "Şifrele / Çöz",
   "nav_keys": "Anahtarlar",
   "nav_settings": "Ayarlar",
-
   "home_title": "KeychainPGP",
   "home_tagline_clipboard": "Metni kopyalayın, ardından aşağıdan bir işlem seçin.",
   "home_tagline_compose": "Mesajınızı yazın, ardından aşağıdan bir işlem seçin.",
   "mode_clipboard": "Pano",
   "mode_compose": "Yaz",
-
   "action_encrypt": "ŞİFRELE",
   "action_decrypt": "ÇÖZ",
   "action_sign": "İMZALA",
   "action_verify": "DOĞRULA",
-
   "clipboard_label": "Pano",
   "clipboard_empty": "Panonuz boş. Başlamak için bir metin kopyalayın.",
   "clipboard_pgp_message": "PGP Mesajı",
   "clipboard_signed_message": "İmzalı Mesaj",
   "clipboard_refresh": "Panoyu yenile",
-
   "compose_label": "Yaz",
   "compose_placeholder": "Mesajınızı buraya yazın veya yapıştırın...",
   "compose_clear": "Temizle",
-
   "encrypt_empty_clipboard": "Pano boş. Önce bir metin kopyalayın.",
   "encrypt_empty_compose": "Yazma alanı boş. Önce bir mesaj yazın.",
   "encrypt_no_keys": "Kullanılabilir anahtar yok. Önce bir anahtar oluşturun veya içe aktarın.",
-
   "decrypt_empty_clipboard": "Pano boş. Önce şifrelenmiş bir mesaj kopyalayın.",
   "decrypt_empty_compose": "Yazma alanı boş.",
   "decrypt_no_pgp": "PGP mesajı algılanamadı.",
   "decrypt_in_progress": "Çözülüyor...",
   "decrypt_success": "Başarıyla çözüldü.",
   "decrypt_wrong_key_hint": "Doğru özel anahtarın içe aktarılmış olduğundan emin olun.",
-
   "sign_empty_clipboard": "Pano boş. Önce bir metin kopyalayın.",
   "sign_empty_compose": "Yazma alanı boş.",
   "sign_no_key": "Kullanılabilir özel anahtar yok. Önce bir anahtar oluşturun veya içe aktarın.",
   "sign_in_progress": "İmzalanıyor...",
   "sign_success_compose": "Mesaj imzalandı.",
-
   "verify_empty_clipboard": "Pano boş. Önce imzalanmış bir mesaj kopyalayın.",
   "verify_empty_compose": "Yazma alanı boş.",
   "verify_in_progress": "Doğrulanıyor...",
   "verify_success": "İmza doğrulandı.",
   "verify_failed": "Doğrulama başarısız.",
-
   "verify_modal_title": "İmza Doğrulama",
   "verify_valid_verified": "Geçerli İmza — Doğrulanmış",
   "verify_valid_verified_desc": "Bu mesaj doğrulanmış bir anahtarla imzalanmıştır.",
@@ -61,7 +50,6 @@
   "verify_signer_label": "İmzacı",
   "verify_email_label": "E-posta",
   "verify_fingerprint_label": "Parmak İzi",
-
   "keys_title": "Anahtar Yöneticisi",
   "keys_generate": "Oluştur",
   "keys_import_btn": "İçe Aktar",
@@ -74,7 +62,6 @@
   "keys_section_contacts": "Kişiler",
   "keys_export_success": "Açık anahtar panoya kopyalandı.",
   "keys_deleted": "Anahtar silindi.",
-
   "key_details_title": "Anahtar Ayrıntıları",
   "key_details_btn": "Ayrıntılar",
   "key_export_btn": "Açık anahtarı dışa aktar",
@@ -102,7 +89,6 @@
   "key_details_qr_btn": "QR Kodu",
   "key_details_not_found": "Anahtar bulunamadı.",
   "key_trust_update_failed": "Güven güncellenemedi: {error}",
-
   "keygen_title": "Yeni Anahtar Çifti Oluştur",
   "keygen_name_placeholder": "Ad",
   "keygen_email_placeholder": "E-posta",
@@ -112,7 +98,6 @@
   "keygen_submit": "Oluştur",
   "keygen_loading": "Oluşturuluyor...",
   "keygen_success": "Anahtar çifti başarıyla oluşturuldu!",
-
   "onboarding_title": "KeychainPGP'ye Hoş Geldiniz",
   "onboarding_subtitle": "Pano şifrelemesine başlamak için ilk anahtar çiftinizi oluşturun.",
   "onboarding_name_placeholder": "Adınız",
@@ -123,7 +108,6 @@
   "onboarding_import": "Mevcut Anahtarı İçe Aktar",
   "onboarding_scan_qr": "QR Kod Tara",
   "onboarding_sync": "Başka bir cihazdan senkronize et",
-
   "recipient_title": "Alıcıları Seçin",
   "recipient_search_placeholder": "Anahtar ara...",
   "recipient_no_keys": "Kullanılabilir anahtar yok.",
@@ -136,7 +120,6 @@
   "recipient_encrypt_btn_other": "{count} alıcı için şifrele",
   "recipient_encrypting": "Şifreleniyor...",
   "recipient_encrypt_success": "Mesaj şifrelendi ve panoya kopyalandı.",
-
   "import_title": "Anahtar İçe Aktar",
   "import_textarea_placeholder": "ASCII-armored PGP anahtarını veya yedek dosyasını yapıştırın...",
   "import_or": "veya",
@@ -155,32 +138,26 @@
   "import_backup_success_one": "1 anahtar içe aktarıldı",
   "import_backup_success_other": "{count} anahtar içe aktarıldı",
   "import_backup_skipped": ", {count} anahtar zaten anahtarlıkta",
-
   "passphrase_title": "Parola Girin",
   "passphrase_desc": "Bu anahtar parola ile korunuyor. Çözmek için parolayı girin.",
   "passphrase_placeholder": "Parola",
   "passphrase_cancel": "İptal",
   "passphrase_submit": "Çöz",
-
   "decrypted_title": "Çözülmüş Mesaj",
   "decrypted_copy": "Kopyala",
   "decrypted_copied": "Kopyalandı",
   "decrypted_close": "Kapat",
-
   "error_title": "Hata",
   "error_fallback": "Beklenmeyen bir hata oluştu.",
   "error_ok": "Tamam",
-
   "confirm_default_title": "Onay",
   "confirm_default_message": "Emin misiniz?",
   "confirm_cancel": "İptal",
   "confirm_delete": "Sil",
-
   "qr_title": "QR Kodu Dışa Aktarma",
   "qr_generating": "QR kodu oluşturuluyor...",
   "qr_desc": "Açık anahtarı içe aktarmak için bu QR kodunu tarayın.",
   "qr_close": "Kapat",
-
   "discovery_title": "Anahtar Keşfet",
   "discovery_placeholder": "E-posta adresi veya ad...",
   "discovery_search": "Ara",
@@ -190,11 +167,9 @@
   "discovery_import_hint": "Keşfedilen bir anahtarı içe aktarmak için açık anahtarını kopyalayın ve Anahtarlar görünümündeki İçe Aktar işlevini kullanın.",
   "discovery_import_fail": "İçe aktarma için anahtar verileri alınamadı.",
   "discovery_close": "Kapat",
-
   "trust_unknown": "Bilinmiyor",
   "trust_imported": "İçe Aktarılmış",
   "trust_verified": "Doğrulanmış",
-
   "settings_title": "Ayarlar",
   "settings_appearance": "Görünüm",
   "settings_theme_system": "Sistem",
@@ -202,13 +177,11 @@
   "settings_theme_dark": "Koyu",
   "settings_close_to_tray_label": "Tepsi alanına küçült",
   "settings_close_to_tray_desc": "Pencereyi kapattığınızda uygulamayı sistem tepsisinde çalışır durumda tut",
-
   "settings_clipboard": "Pano",
   "settings_auto_clear_label": "Panoyu otomatik temizle",
   "settings_auto_clear_desc": "Çözme işleminden sonra panodan hassas verileri temizle",
   "settings_auto_clear_delay_label": "Otomatik temizleme gecikmesi",
   "settings_auto_clear_delay_desc": "Panonun temizlenmesine kadar geçecek süre (saniye)",
-
   "settings_encryption": "Şifreleme",
   "settings_encrypt_to_self_label": "Kendine de şifrele",
   "settings_encrypt_to_self_desc": "Kendi anahtarınızı her zaman alıcı olarak ekle",
@@ -217,22 +190,18 @@
   "settings_self_keys_count_other": "{count} anahtar seçili.",
   "settings_include_armor_label": "Zırh başlıklarını ekle",
   "settings_include_armor_desc": "PGP çıktısına Sürüm ve Yorum meta verilerini ekle",
-
   "settings_security": "Güvenlik",
   "settings_passphrase_cache_label": "Parola önbellek süresi",
   "settings_passphrase_cache_desc": "Parolaların hatırlanma süresi (saniye, 0 = devre dışı)",
   "settings_clear_cache": "Önbelleğe alınmış parolaları temizle",
   "settings_cache_cleared": "Parola önbelleği temizlendi.",
   "settings_cache_clear_failed": "Önbellek temizlenemedi: {error}",
-
   "settings_key_discovery": "Anahtar Keşfi",
   "settings_keyserver_label": "Anahtar sunucusu URL'si",
   "settings_keyserver_desc": "Anahtar arama ve yükleme için kullanılır",
-
   "settings_language": "Dil",
   "settings_language_label": "Görüntüleme dili",
   "settings_language_desc": "Arayüz dilini seçin",
-
   "settings_sync": "Anahtar Senkronizasyonu",
   "settings_sync_desc": "Anahtarlarınızı cihazlar arasında güvenle aktarın.",
   "settings_sync_export": "Anahtarları Dışa Aktar",
@@ -258,7 +227,6 @@
   "sync_error_no_passphrase": "Dışa aktaran cihazda gösterilen senkronizasyon parolasını girin.",
   "done": "Tamam",
   "cancel": "İptal",
-
   "settings_opsec": "OPSEC Modu",
   "settings_opsec_desc": "Yüksek riskli ortamlar için güçlendirilmiş mod. Anahtarlar yalnızca RAM'de saklanır ve çıkışta silinir.",
   "settings_opsec_enable": "OPSEC Modunu Etkinleştir",
@@ -280,9 +248,8 @@
   "settings_proxy_success": "Bağlantı başarılı!",
   "settings_proxy_failed": "Bağlantı başarısız: {error}",
   "settings_proxy_custom": "Özel",
-
-  "settings_about": "KeychainPGP {version} — Masaüstü için pano odaklı PGP şifreleme.",
   "settings_about_title": "Hakkında",
+  "settings_about": "KeychainPGP {version} — Masaüstü için pano odaklı PGP şifreleme.",
   "settings_portable_badge": "Taşınabilir Mod",
   "donate_button": "Bu projeyi destekle",
   "donate_title": "KeychainPGP'yi Destekle",
@@ -294,12 +261,10 @@
   "donate_eth": "Ethereum",
   "donate_xmr": "Monero",
   "donate_thanks": "Desteğiniz için teşekkürler!",
-
   "unnamed": "(isimsiz)",
   "none_value": "(yok)",
   "date_na": "Yok",
   "fingerprint_copy": "Parmak izini kopyala",
-
   "kbd_ctrl": "Ctrl",
   "kbd_shift": "Shift"
 }

--- a/crates/keychainpgp-ui/frontend/messages/uk.json
+++ b/crates/keychainpgp-ui/frontend/messages/uk.json
@@ -1,57 +1,46 @@
 {
   "$schema": "https://inlang.com/schema/inlang-message-format",
-
   "loading": "Завантаження...",
   "ready": "Готово",
-
   "nav_home": "Шифрування / Розшифрування",
   "nav_keys": "Ключі",
   "nav_settings": "Налаштування",
-
   "home_title": "KeychainPGP",
   "home_tagline_clipboard": "Скопіюйте текст, потім оберіть дію нижче.",
   "home_tagline_compose": "Введіть повідомлення, потім оберіть дію нижче.",
   "mode_clipboard": "Буфер обміну",
   "mode_compose": "Редактор",
-
   "action_encrypt": "ЗАШИФРУВАТИ",
   "action_decrypt": "РОЗШИФРУВАТИ",
   "action_sign": "ПІДПИСАТИ",
   "action_verify": "ПЕРЕВІРИТИ",
-
   "clipboard_label": "Буфер обміну",
   "clipboard_empty": "Буфер обміну порожній. Скопіюйте текст, щоб почати.",
   "clipboard_pgp_message": "Повідомлення PGP",
   "clipboard_signed_message": "Підписане повідомлення",
   "clipboard_refresh": "Оновити буфер обміну",
-
   "compose_label": "Редактор",
   "compose_placeholder": "Введіть або вставте повідомлення...",
   "compose_clear": "Очистити",
-
   "encrypt_empty_clipboard": "Буфер обміну порожній. Спершу скопіюйте текст.",
   "encrypt_empty_compose": "Поле введення порожнє. Спершу введіть повідомлення.",
   "encrypt_no_keys": "Немає доступних ключів. Спершу створіть або імпортуйте ключ.",
-
   "decrypt_empty_clipboard": "Буфер обміну порожній. Спершу скопіюйте зашифроване повідомлення.",
   "decrypt_empty_compose": "Поле введення порожнє.",
   "decrypt_no_pgp": "Повідомлення PGP не виявлено.",
   "decrypt_in_progress": "Розшифрування...",
   "decrypt_success": "Успішно розшифровано.",
   "decrypt_wrong_key_hint": "Переконайтеся, що у вас імпортовано правильний закритий ключ.",
-
   "sign_empty_clipboard": "Буфер обміну порожній. Спершу скопіюйте текст.",
   "sign_empty_compose": "Поле введення порожнє.",
   "sign_no_key": "Немає закритого ключа. Спершу створіть або імпортуйте його.",
   "sign_in_progress": "Підписання...",
   "sign_success_compose": "Повідомлення підписано.",
-
   "verify_empty_clipboard": "Буфер обміну порожній. Спершу скопіюйте підписане повідомлення.",
   "verify_empty_compose": "Поле введення порожнє.",
   "verify_in_progress": "Перевірка...",
   "verify_success": "Підпис підтверджено.",
   "verify_failed": "Перевірку не пройдено.",
-
   "verify_modal_title": "Перевірка підпису",
   "verify_valid_verified": "Дійсний підпис — перевірений ключ",
   "verify_valid_verified_desc": "Це повідомлення підписано перевіреним ключем.",
@@ -61,7 +50,6 @@
   "verify_signer_label": "Підписант",
   "verify_email_label": "Ел. пошта",
   "verify_fingerprint_label": "Відбиток",
-
   "keys_title": "Керування ключами",
   "keys_generate": "Створити",
   "keys_import_btn": "Імпорт",
@@ -74,7 +62,6 @@
   "keys_section_contacts": "Контакти",
   "keys_export_success": "Відкритий ключ скопійовано до буфера обміну.",
   "keys_deleted": "Ключ видалено.",
-
   "key_details_title": "Відомості про ключ",
   "key_details_btn": "Детальніше",
   "key_export_btn": "Експортувати відкритий ключ",
@@ -102,7 +89,6 @@
   "key_details_qr_btn": "QR-код",
   "key_details_not_found": "Ключ не знайдено.",
   "key_trust_update_failed": "Не вдалося оновити довіру: {error}",
-
   "keygen_title": "Створення нової пари ключів",
   "keygen_name_placeholder": "Ім'я",
   "keygen_email_placeholder": "Ел. пошта",
@@ -112,7 +98,6 @@
   "keygen_submit": "Створити",
   "keygen_loading": "Створення...",
   "keygen_success": "Пару ключів успішно створено!",
-
   "onboarding_title": "Ласкаво просимо до KeychainPGP",
   "onboarding_subtitle": "Створіть свою першу пару ключів, щоб почати шифрування через буфер обміну.",
   "onboarding_name_placeholder": "Ваше ім'я",
@@ -123,7 +108,6 @@
   "onboarding_import": "Імпортувати наявний ключ",
   "onboarding_scan_qr": "Сканувати QR-код",
   "onboarding_sync": "Синхронізація з іншого пристрою",
-
   "recipient_title": "Вибір отримувачів",
   "recipient_search_placeholder": "Пошук ключів...",
   "recipient_no_keys": "Немає доступних ключів.",
@@ -136,7 +120,6 @@
   "recipient_encrypt_btn_other": "Зашифрувати для {count} отримувачів",
   "recipient_encrypting": "Шифрування...",
   "recipient_encrypt_success": "Повідомлення зашифровано та скопійовано до буфера обміну.",
-
   "import_title": "Імпорт ключа",
   "import_textarea_placeholder": "Вставте PGP-ключ у форматі ASCII-armored або файл резервної копії...",
   "import_or": "або",
@@ -155,32 +138,26 @@
   "import_backup_success_one": "Імпортовано 1 ключ",
   "import_backup_success_other": "Імпортовано ключів: {count}",
   "import_backup_skipped": ", {count} вже у зв'язці ключів",
-
   "passphrase_title": "Введіть парольну фразу",
   "passphrase_desc": "Цей ключ захищено парольною фразою. Введіть її для розшифрування.",
   "passphrase_placeholder": "Парольна фраза",
   "passphrase_cancel": "Скасувати",
   "passphrase_submit": "Розшифрувати",
-
   "decrypted_title": "Розшифроване повідомлення",
   "decrypted_copy": "Копіювати",
   "decrypted_copied": "Скопійовано",
   "decrypted_close": "Закрити",
-
   "error_title": "Помилка",
   "error_fallback": "Сталася непередбачена помилка.",
   "error_ok": "ОК",
-
   "confirm_default_title": "Підтвердження",
   "confirm_default_message": "Ви впевнені?",
   "confirm_cancel": "Скасувати",
   "confirm_delete": "Видалити",
-
   "qr_title": "Експорт QR-коду",
   "qr_generating": "Створення QR-коду...",
   "qr_desc": "Відскануйте цей QR-код, щоб імпортувати відкритий ключ.",
   "qr_close": "Закрити",
-
   "discovery_title": "Пошук ключів",
   "discovery_placeholder": "Адреса електронної пошти або ім'я...",
   "discovery_search": "Знайти",
@@ -190,11 +167,9 @@
   "discovery_import_hint": "Щоб імпортувати знайдений ключ, скопіюйте його відкритий ключ і скористайтеся функцією імпорту на вкладці «Ключі».",
   "discovery_import_fail": "Не вдалося отримати дані ключа для імпорту.",
   "discovery_close": "Закрити",
-
   "trust_unknown": "Невідомо",
   "trust_imported": "Імпортовано",
   "trust_verified": "Перевірено",
-
   "settings_title": "Налаштування",
   "settings_appearance": "Оформлення",
   "settings_theme_system": "Системна",
@@ -202,13 +177,11 @@
   "settings_theme_dark": "Темна",
   "settings_close_to_tray_label": "Згортати в трей",
   "settings_close_to_tray_desc": "Залишати додаток в області сповіщень при закритті вікна",
-
   "settings_clipboard": "Буфер обміну",
   "settings_auto_clear_label": "Автоочищення буфера обміну",
   "settings_auto_clear_desc": "Очищати конфіденційні дані з буфера обміну після розшифрування",
   "settings_auto_clear_delay_label": "Затримка автоочищення",
   "settings_auto_clear_delay_desc": "Секунди до очищення буфера обміну",
-
   "settings_encryption": "Шифрування",
   "settings_encrypt_to_self_label": "Шифрувати для себе",
   "settings_encrypt_to_self_desc": "Завжди включати ваш ключ до списку отримувачів",
@@ -217,22 +190,18 @@
   "settings_self_keys_count_other": "Обрано ключів: {count}.",
   "settings_include_armor_label": "Включати заголовки ASCII-armored",
   "settings_include_armor_desc": "Додавати метадані Version та Comment до виводу PGP",
-
   "settings_security": "Безпека",
   "settings_passphrase_cache_label": "Час кешування парольної фрази",
   "settings_passphrase_cache_desc": "Секунди зберігання парольних фраз (0 = вимкнено)",
   "settings_clear_cache": "Очистити кеш парольних фраз",
   "settings_cache_cleared": "Кеш парольних фраз очищено.",
   "settings_cache_clear_failed": "Не вдалося очистити кеш: {error}",
-
   "settings_key_discovery": "Пошук ключів",
   "settings_keyserver_label": "URL сервера ключів",
   "settings_keyserver_desc": "Використовується для пошуку та завантаження ключів",
-
   "settings_language": "Мова",
   "settings_language_label": "Мова інтерфейсу",
   "settings_language_desc": "Оберіть мову інтерфейсу",
-
   "settings_sync": "Синхронізація ключів",
   "settings_sync_desc": "Безпечна передача ключів між пристроями.",
   "settings_sync_export": "Експортувати ключі",
@@ -258,7 +227,6 @@
   "sync_error_no_passphrase": "Введіть парольну фразу синхронізації, показану на експортуючому пристрої.",
   "done": "Готово",
   "cancel": "Скасувати",
-
   "settings_opsec": "Режим OPSEC",
   "settings_opsec_desc": "Посилений режим для середовищ з високим ризиком. Ключі зберігаються лише в оперативній пам'яті та знищуються при виході.",
   "settings_opsec_enable": "Увімкнути режим OPSEC",
@@ -280,9 +248,8 @@
   "settings_proxy_success": "З'єднання успішне!",
   "settings_proxy_failed": "Помилка з'єднання: {error}",
   "settings_proxy_custom": "Інший",
-
-  "settings_about": "KeychainPGP {version} — PGP-шифрування через буфер обміну для настільних систем.",
   "settings_about_title": "Про програму",
+  "settings_about": "KeychainPGP {version} — PGP-шифрування через буфер обміну для настільних систем.",
   "settings_portable_badge": "Портативний режим",
   "donate_button": "Підтримати цей проєкт",
   "donate_title": "Підтримати KeychainPGP",
@@ -294,12 +261,10 @@
   "donate_eth": "Ethereum",
   "donate_xmr": "Monero",
   "donate_thanks": "Дякуємо за вашу підтримку!",
-
   "unnamed": "(без імені)",
   "none_value": "(немає)",
   "date_na": "Н/Д",
   "fingerprint_copy": "Копіювати відбиток",
-
   "kbd_ctrl": "Ctrl",
   "kbd_shift": "Shift"
 }

--- a/crates/keychainpgp-ui/frontend/messages/zh-CN.json
+++ b/crates/keychainpgp-ui/frontend/messages/zh-CN.json
@@ -1,57 +1,46 @@
 {
   "$schema": "https://inlang.com/schema/inlang-message-format",
-
   "loading": "加载中...",
   "ready": "就绪",
-
   "nav_home": "加密 / 解密",
   "nav_keys": "密钥",
   "nav_settings": "设置",
-
   "home_title": "KeychainPGP",
   "home_tagline_clipboard": "复制文本，然后选择下方的操作。",
   "home_tagline_compose": "输入消息，然后选择下方的操作。",
   "mode_clipboard": "剪贴板",
   "mode_compose": "编写",
-
   "action_encrypt": "加密",
   "action_decrypt": "解密",
   "action_sign": "签名",
   "action_verify": "验证",
-
   "clipboard_label": "剪贴板",
   "clipboard_empty": "剪贴板为空。请先复制一些文本。",
   "clipboard_pgp_message": "PGP 消息",
   "clipboard_signed_message": "已签名消息",
   "clipboard_refresh": "刷新剪贴板",
-
   "compose_label": "编写",
   "compose_placeholder": "在此输入或粘贴消息...",
   "compose_clear": "清除",
-
   "encrypt_empty_clipboard": "剪贴板为空。请先复制一些文本。",
   "encrypt_empty_compose": "编写区域为空。请先输入消息。",
   "encrypt_no_keys": "没有可用的密钥。请先生成或导入密钥。",
-
   "decrypt_empty_clipboard": "剪贴板为空。请先复制加密消息。",
   "decrypt_empty_compose": "编写区域为空。",
   "decrypt_no_pgp": "未检测到 PGP 消息。",
   "decrypt_in_progress": "正在解密...",
   "decrypt_success": "解密成功。",
   "decrypt_wrong_key_hint": "请确保已导入正确的私钥。",
-
   "sign_empty_clipboard": "剪贴板为空。请先复制一些文本。",
   "sign_empty_compose": "编写区域为空。",
   "sign_no_key": "没有可用的私钥。请先生成或导入私钥。",
   "sign_in_progress": "正在签名...",
   "sign_success_compose": "消息已签名。",
-
   "verify_empty_clipboard": "剪贴板为空。请先复制已签名的消息。",
   "verify_empty_compose": "编写区域为空。",
   "verify_in_progress": "正在验证...",
   "verify_success": "签名验证通过。",
   "verify_failed": "验证失败。",
-
   "verify_modal_title": "签名验证",
   "verify_valid_verified": "有效签名 — 已验证",
   "verify_valid_verified_desc": "此消息由已验证的密钥签名。",
@@ -61,7 +50,6 @@
   "verify_signer_label": "签名者",
   "verify_email_label": "电子邮件",
   "verify_fingerprint_label": "指纹",
-
   "keys_title": "密钥管理",
   "keys_generate": "生成",
   "keys_import_btn": "导入",
@@ -74,7 +62,6 @@
   "keys_section_contacts": "联系人",
   "keys_export_success": "公钥已复制到剪贴板。",
   "keys_deleted": "密钥已删除。",
-
   "key_details_title": "密钥详情",
   "key_details_btn": "详情",
   "key_export_btn": "导出公钥",
@@ -102,7 +89,6 @@
   "key_details_qr_btn": "二维码",
   "key_details_not_found": "未找到密钥。",
   "key_trust_update_failed": "更新信任度失败：{error}",
-
   "keygen_title": "生成新密钥对",
   "keygen_name_placeholder": "名称",
   "keygen_email_placeholder": "电子邮件",
@@ -112,7 +98,6 @@
   "keygen_submit": "生成",
   "keygen_loading": "正在生成...",
   "keygen_success": "密钥对生成成功！",
-
   "onboarding_title": "欢迎使用 KeychainPGP",
   "onboarding_subtitle": "生成您的第一个密钥对，开始使用剪贴板加密功能。",
   "onboarding_name_placeholder": "您的名称",
@@ -123,7 +108,6 @@
   "onboarding_import": "导入已有密钥",
   "onboarding_scan_qr": "扫描二维码",
   "onboarding_sync": "从其他设备同步",
-
   "recipient_title": "选择收件人",
   "recipient_search_placeholder": "搜索密钥...",
   "recipient_no_keys": "没有可用的密钥。",
@@ -136,7 +120,6 @@
   "recipient_encrypt_btn_other": "为 {count} 位收件人加密",
   "recipient_encrypting": "正在加密...",
   "recipient_encrypt_success": "消息已加密并复制到剪贴板。",
-
   "import_title": "导入密钥",
   "import_textarea_placeholder": "粘贴 ASCII-armored PGP 密钥或备份文件...",
   "import_or": "或",
@@ -155,32 +138,26 @@
   "import_backup_success_one": "已导入 1 个密钥",
   "import_backup_success_other": "已导入 {count} 个密钥",
   "import_backup_skipped": "，{count} 个已在密钥环中",
-
   "passphrase_title": "输入密码短语",
   "passphrase_desc": "此密钥受密码短语保护。请输入密码短语以解密。",
   "passphrase_placeholder": "密码短语",
   "passphrase_cancel": "取消",
   "passphrase_submit": "解密",
-
   "decrypted_title": "已解密消息",
   "decrypted_copy": "复制",
   "decrypted_copied": "已复制",
   "decrypted_close": "关闭",
-
   "error_title": "错误",
   "error_fallback": "发生了意外错误。",
   "error_ok": "确定",
-
   "confirm_default_title": "确认",
   "confirm_default_message": "确定要继续吗？",
   "confirm_cancel": "取消",
   "confirm_delete": "删除",
-
   "qr_title": "二维码导出",
   "qr_generating": "正在生成二维码...",
   "qr_desc": "扫描此二维码以导入公钥。",
   "qr_close": "关闭",
-
   "discovery_title": "发现密钥",
   "discovery_placeholder": "电子邮件地址或名称...",
   "discovery_search": "搜索",
@@ -190,11 +167,9 @@
   "discovery_import_hint": "要导入发现的密钥，请复制其公钥，然后在密钥视图中使用导入功能。",
   "discovery_import_fail": "无法获取密钥数据以进行导入。",
   "discovery_close": "关闭",
-
   "trust_unknown": "未知",
   "trust_imported": "已导入",
   "trust_verified": "已验证",
-
   "settings_title": "设置",
   "settings_appearance": "外观",
   "settings_theme_system": "跟随系统",
@@ -202,13 +177,11 @@
   "settings_theme_dark": "深色",
   "settings_close_to_tray_label": "关闭到托盘",
   "settings_close_to_tray_desc": "关闭窗口时保持应用在系统托盘中运行",
-
   "settings_clipboard": "剪贴板",
   "settings_auto_clear_label": "自动清除剪贴板",
   "settings_auto_clear_desc": "解密后自动清除剪贴板中的敏感数据",
   "settings_auto_clear_delay_label": "自动清除延迟",
   "settings_auto_clear_delay_desc": "清除剪贴板前的等待秒数",
-
   "settings_encryption": "加密",
   "settings_encrypt_to_self_label": "同时加密给自己",
   "settings_encrypt_to_self_desc": "始终将自己的密钥包含为收件人",
@@ -217,22 +190,18 @@
   "settings_self_keys_count_other": "已选择 {count} 个密钥。",
   "settings_include_armor_label": "包含 armor 头部",
   "settings_include_armor_desc": "在 PGP 输出中添加版本和注释元数据",
-
   "settings_security": "安全",
   "settings_passphrase_cache_label": "密码短语缓存时长",
   "settings_passphrase_cache_desc": "记住密码短语的秒数（0 = 禁用）",
   "settings_clear_cache": "清除已缓存的密码短语",
   "settings_cache_cleared": "密码短语缓存已清除。",
   "settings_cache_clear_failed": "清除缓存失败：{error}",
-
   "settings_key_discovery": "密钥发现",
   "settings_keyserver_label": "密钥服务器 URL",
   "settings_keyserver_desc": "用于密钥搜索和上传",
-
   "settings_language": "语言",
   "settings_language_label": "显示语言",
   "settings_language_desc": "选择界面语言",
-
   "settings_sync": "密钥同步",
   "settings_sync_desc": "在设备之间安全地传输密钥。",
   "settings_sync_export": "导出密钥",
@@ -258,7 +227,6 @@
   "sync_error_no_passphrase": "请输入导出设备上显示的同步密码短语。",
   "done": "完成",
   "cancel": "取消",
-
   "settings_opsec": "OPSEC 模式",
   "settings_opsec_desc": "高风险环境下的强化模式。密钥仅存储在内存中，退出时自动擦除。",
   "settings_opsec_enable": "启用 OPSEC 模式",
@@ -280,9 +248,8 @@
   "settings_proxy_success": "连接成功！",
   "settings_proxy_failed": "连接失败：{error}",
   "settings_proxy_custom": "自定义",
-
-  "settings_about": "KeychainPGP {version} — 桌面端剪贴板优先的 PGP 加密工具。",
   "settings_about_title": "关于",
+  "settings_about": "KeychainPGP {version} — 桌面端剪贴板优先的 PGP 加密工具。",
   "settings_portable_badge": "便携模式",
   "donate_button": "支持此项目",
   "donate_title": "支持 KeychainPGP",
@@ -294,12 +261,10 @@
   "donate_eth": "Ethereum",
   "donate_xmr": "Monero",
   "donate_thanks": "感谢您的支持！",
-
   "unnamed": "（未命名）",
   "none_value": "（无）",
   "date_na": "不适用",
   "fingerprint_copy": "复制指纹",
-
   "kbd_ctrl": "Ctrl",
   "kbd_shift": "Shift"
 }

--- a/crates/keychainpgp-ui/frontend/messages/zh-TW.json
+++ b/crates/keychainpgp-ui/frontend/messages/zh-TW.json
@@ -1,57 +1,46 @@
 {
   "$schema": "https://inlang.com/schema/inlang-message-format",
-
   "loading": "載入中...",
   "ready": "就緒",
-
   "nav_home": "加密 / 解密",
   "nav_keys": "金鑰",
   "nav_settings": "設定",
-
   "home_title": "KeychainPGP",
   "home_tagline_clipboard": "複製文字，然後選擇下方的操作。",
   "home_tagline_compose": "輸入訊息，然後選擇下方的操作。",
   "mode_clipboard": "剪貼簿",
   "mode_compose": "撰寫",
-
   "action_encrypt": "加密",
   "action_decrypt": "解密",
   "action_sign": "簽署",
   "action_verify": "驗證",
-
   "clipboard_label": "剪貼簿",
   "clipboard_empty": "剪貼簿為空。請先複製一些文字。",
   "clipboard_pgp_message": "PGP 訊息",
   "clipboard_signed_message": "已簽署訊息",
   "clipboard_refresh": "重新整理剪貼簿",
-
   "compose_label": "撰寫",
   "compose_placeholder": "在此輸入或貼上訊息...",
   "compose_clear": "清除",
-
   "encrypt_empty_clipboard": "剪貼簿為空。請先複製一些文字。",
   "encrypt_empty_compose": "撰寫區域為空。請先輸入訊息。",
   "encrypt_no_keys": "沒有可用的金鑰。請先產生或匯入金鑰。",
-
   "decrypt_empty_clipboard": "剪貼簿為空。請先複製加密訊息。",
   "decrypt_empty_compose": "撰寫區域為空。",
   "decrypt_no_pgp": "未偵測到 PGP 訊息。",
   "decrypt_in_progress": "正在解密...",
   "decrypt_success": "解密成功。",
   "decrypt_wrong_key_hint": "請確認已匯入正確的私鑰。",
-
   "sign_empty_clipboard": "剪貼簿為空。請先複製一些文字。",
   "sign_empty_compose": "撰寫區域為空。",
   "sign_no_key": "沒有可用的私鑰。請先產生或匯入私鑰。",
   "sign_in_progress": "正在簽署...",
   "sign_success_compose": "訊息已簽署。",
-
   "verify_empty_clipboard": "剪貼簿為空。請先複製已簽署的訊息。",
   "verify_empty_compose": "撰寫區域為空。",
   "verify_in_progress": "正在驗證...",
   "verify_success": "簽章驗證通過。",
   "verify_failed": "驗證失敗。",
-
   "verify_modal_title": "簽章驗證",
   "verify_valid_verified": "有效簽章 — 已驗證",
   "verify_valid_verified_desc": "此訊息由已驗證的金鑰簽署。",
@@ -61,7 +50,6 @@
   "verify_signer_label": "簽署者",
   "verify_email_label": "電子郵件",
   "verify_fingerprint_label": "指紋",
-
   "keys_title": "金鑰管理",
   "keys_generate": "產生",
   "keys_import_btn": "匯入",
@@ -74,7 +62,6 @@
   "keys_section_contacts": "聯絡人",
   "keys_export_success": "公鑰已複製到剪貼簿。",
   "keys_deleted": "金鑰已刪除。",
-
   "key_details_title": "金鑰詳情",
   "key_details_btn": "詳情",
   "key_export_btn": "匯出公鑰",
@@ -102,7 +89,6 @@
   "key_details_qr_btn": "QR Code",
   "key_details_not_found": "未找到金鑰。",
   "key_trust_update_failed": "更新信任度失敗：{error}",
-
   "keygen_title": "產生新金鑰對",
   "keygen_name_placeholder": "名稱",
   "keygen_email_placeholder": "電子郵件",
@@ -112,7 +98,6 @@
   "keygen_submit": "產生",
   "keygen_loading": "正在產生...",
   "keygen_success": "金鑰對產生成功！",
-
   "onboarding_title": "歡迎使用 KeychainPGP",
   "onboarding_subtitle": "產生您的第一組金鑰對，開始使用剪貼簿加密功能。",
   "onboarding_name_placeholder": "您的名稱",
@@ -123,7 +108,6 @@
   "onboarding_import": "匯入現有金鑰",
   "onboarding_scan_qr": "掃描 QR 碼",
   "onboarding_sync": "從其他裝置同步",
-
   "recipient_title": "選擇收件人",
   "recipient_search_placeholder": "搜尋金鑰...",
   "recipient_no_keys": "沒有可用的金鑰。",
@@ -136,7 +120,6 @@
   "recipient_encrypt_btn_other": "為 {count} 位收件人加密",
   "recipient_encrypting": "正在加密...",
   "recipient_encrypt_success": "訊息已加密並複製到剪貼簿。",
-
   "import_title": "匯入金鑰",
   "import_textarea_placeholder": "貼上 ASCII-armored PGP 金鑰或備份檔案...",
   "import_or": "或",
@@ -155,32 +138,26 @@
   "import_backup_success_one": "已匯入 1 把金鑰",
   "import_backup_success_other": "已匯入 {count} 把金鑰",
   "import_backup_skipped": "，{count} 把已在金鑰環中",
-
   "passphrase_title": "輸入密碼短語",
   "passphrase_desc": "此金鑰受密碼短語保護。請輸入密碼短語以解密。",
   "passphrase_placeholder": "密碼短語",
   "passphrase_cancel": "取消",
   "passphrase_submit": "解密",
-
   "decrypted_title": "已解密訊息",
   "decrypted_copy": "複製",
   "decrypted_copied": "已複製",
   "decrypted_close": "關閉",
-
   "error_title": "錯誤",
   "error_fallback": "發生了非預期的錯誤。",
   "error_ok": "確定",
-
   "confirm_default_title": "確認",
   "confirm_default_message": "確定要繼續嗎？",
   "confirm_cancel": "取消",
   "confirm_delete": "刪除",
-
   "qr_title": "QR Code 匯出",
   "qr_generating": "正在產生 QR Code...",
   "qr_desc": "掃描此 QR Code 以匯入公鑰。",
   "qr_close": "關閉",
-
   "discovery_title": "探索金鑰",
   "discovery_placeholder": "電子郵件地址或名稱...",
   "discovery_search": "搜尋",
@@ -190,11 +167,9 @@
   "discovery_import_hint": "若要匯入探索到的金鑰，請複製其公鑰，然後在金鑰檢視中使用匯入功能。",
   "discovery_import_fail": "無法取得金鑰資料以進行匯入。",
   "discovery_close": "關閉",
-
   "trust_unknown": "未知",
   "trust_imported": "已匯入",
   "trust_verified": "已驗證",
-
   "settings_title": "設定",
   "settings_appearance": "外觀",
   "settings_theme_system": "跟隨系統",
@@ -202,13 +177,11 @@
   "settings_theme_dark": "深色",
   "settings_close_to_tray_label": "關閉至系統匣",
   "settings_close_to_tray_desc": "關閉視窗時保持應用程式在系統匣中執行",
-
   "settings_clipboard": "剪貼簿",
   "settings_auto_clear_label": "自動清除剪貼簿",
   "settings_auto_clear_desc": "解密後自動清除剪貼簿中的敏感資料",
   "settings_auto_clear_delay_label": "自動清除延遲",
   "settings_auto_clear_delay_desc": "清除剪貼簿前的等待秒數",
-
   "settings_encryption": "加密",
   "settings_encrypt_to_self_label": "同時加密給自己",
   "settings_encrypt_to_self_desc": "始終將自己的金鑰包含為收件人",
@@ -217,22 +190,18 @@
   "settings_self_keys_count_other": "已選擇 {count} 把金鑰。",
   "settings_include_armor_label": "包含 armor 標頭",
   "settings_include_armor_desc": "在 PGP 輸出中加入版本和註解中繼資料",
-
   "settings_security": "安全性",
   "settings_passphrase_cache_label": "密碼短語快取時長",
   "settings_passphrase_cache_desc": "記住密碼短語的秒數（0 = 停用）",
   "settings_clear_cache": "清除已快取的密碼短語",
   "settings_cache_cleared": "密碼短語快取已清除。",
   "settings_cache_clear_failed": "清除快取失敗：{error}",
-
   "settings_key_discovery": "金鑰探索",
   "settings_keyserver_label": "金鑰伺服器 URL",
   "settings_keyserver_desc": "用於金鑰搜尋和上傳",
-
   "settings_language": "語言",
   "settings_language_label": "顯示語言",
   "settings_language_desc": "選擇介面語言",
-
   "settings_sync": "金鑰同步",
   "settings_sync_desc": "在裝置之間安全地傳輸金鑰。",
   "settings_sync_export": "匯出金鑰",
@@ -258,7 +227,6 @@
   "sync_error_no_passphrase": "請輸入匯出裝置上顯示的同步密碼短語。",
   "done": "完成",
   "cancel": "取消",
-
   "settings_opsec": "OPSEC 模式",
   "settings_opsec_desc": "高風險環境下的強化模式。金鑰僅儲存於記憶體中，退出時自動清除。",
   "settings_opsec_enable": "啟用 OPSEC 模式",
@@ -280,9 +248,8 @@
   "settings_proxy_success": "連線成功！",
   "settings_proxy_failed": "連線失敗：{error}",
   "settings_proxy_custom": "自訂",
-
-  "settings_about": "KeychainPGP {version} — 桌面端剪貼簿優先的 PGP 加密工具。",
   "settings_about_title": "關於",
+  "settings_about": "KeychainPGP {version} — 桌面端剪貼簿優先的 PGP 加密工具。",
   "settings_portable_badge": "便攜模式",
   "donate_button": "支持此專案",
   "donate_title": "支持 KeychainPGP",
@@ -294,12 +261,10 @@
   "donate_eth": "Ethereum",
   "donate_xmr": "Monero",
   "donate_thanks": "感謝您的支持！",
-
   "unnamed": "（未命名）",
   "none_value": "（無）",
   "date_na": "不適用",
   "fingerprint_copy": "複製指紋",
-
   "kbd_ctrl": "Ctrl",
   "kbd_shift": "Shift"
 }

--- a/crates/keychainpgp-ui/frontend/package.json
+++ b/crates/keychainpgp-ui/frontend/package.json
@@ -4,10 +4,14 @@
   "version": "0.1.8",
   "type": "module",
   "scripts": {
+    "sync-translations": "node scripts/sync-translations.cjs",
+    "predev": "node scripts/sync-translations.cjs",
     "dev": "vite dev",
+    "prebuild": "node scripts/sync-translations.cjs",
     "build": "vite build",
     "preview": "vite preview",
-    "check": "svelte-check --tsconfig ./tsconfig.json"
+    "check": "svelte-check --tsconfig ./tsconfig.json",
+    "test:i18n": "node scripts/sync-translations.test.cjs"
   },
   "devDependencies": {
     "@sveltejs/vite-plugin-svelte": "^6.2.4",

--- a/crates/keychainpgp-ui/frontend/scripts/sync-translations.cjs
+++ b/crates/keychainpgp-ui/frontend/scripts/sync-translations.cjs
@@ -1,0 +1,78 @@
+/**
+ * sync-translations.js
+ *
+ * Ensures all locale files have the same keys as en.json.
+ * - Missing keys are filled with the English value as fallback.
+ * - Stale keys (present in locale but not in en.json) are removed.
+ *
+ * Run: node scripts/sync-translations.js
+ */
+
+const fs = require("fs");
+const path = require("path");
+
+const MESSAGES_DIR = path.join(__dirname, "..", "messages");
+const SOURCE_LOCALE = "en";
+const SOURCE_FILE = path.join(MESSAGES_DIR, `${SOURCE_LOCALE}.json`);
+
+const source = JSON.parse(fs.readFileSync(SOURCE_FILE, "utf-8"));
+const sourceKeys = Object.keys(source).filter((k) => !k.startsWith("$"));
+
+const localeFiles = fs
+  .readdirSync(MESSAGES_DIR)
+  .filter((f) => f.endsWith(".json") && f !== `${SOURCE_LOCALE}.json`);
+
+let totalAdded = 0;
+let totalRemoved = 0;
+
+for (const file of localeFiles) {
+  const filePath = path.join(MESSAGES_DIR, file);
+  const locale = JSON.parse(fs.readFileSync(filePath, "utf-8"));
+  const localeName = path.basename(file, ".json");
+
+  let added = 0;
+  let removed = 0;
+
+  // Add missing keys with English fallback
+  for (const key of sourceKeys) {
+    if (!(key in locale)) {
+      locale[key] = source[key];
+      added++;
+    }
+  }
+
+  // Remove stale keys not in en.json
+  for (const key of Object.keys(locale)) {
+    if (key.startsWith("$")) continue;
+    if (!(key in source)) {
+      delete locale[key];
+      removed++;
+    }
+  }
+
+  if (added > 0 || removed > 0) {
+    // Rebuild object with $schema first, then keys in en.json order
+    const ordered = {};
+    if (locale["$schema"]) {
+      ordered["$schema"] = locale["$schema"];
+    }
+    for (const key of sourceKeys) {
+      if (key in locale) {
+        ordered[key] = locale[key];
+      }
+    }
+
+    fs.writeFileSync(filePath, JSON.stringify(ordered, null, 2) + "\n", "utf-8");
+    console.log(`  ${localeName}: +${added} added, -${removed} removed`);
+    totalAdded += added;
+    totalRemoved += removed;
+  }
+}
+
+if (totalAdded === 0 && totalRemoved === 0) {
+  console.log("sync-translations: all locales are in sync.");
+} else {
+  console.log(
+    `sync-translations: ${totalAdded} key(s) added, ${totalRemoved} key(s) removed across ${localeFiles.length} locales.`
+  );
+}

--- a/crates/keychainpgp-ui/frontend/scripts/sync-translations.test.cjs
+++ b/crates/keychainpgp-ui/frontend/scripts/sync-translations.test.cjs
@@ -1,0 +1,102 @@
+/**
+ * Tests for sync-translations.cjs
+ *
+ * Run: node scripts/sync-translations.test.cjs
+ */
+
+const fs = require("fs");
+const path = require("path");
+const { execSync } = require("child_process");
+
+const MESSAGES_DIR = path.join(__dirname, "..", "messages");
+const SCRIPT = path.join(__dirname, "sync-translations.cjs");
+
+let passed = 0;
+let failed = 0;
+
+function assert(condition, name) {
+  if (condition) {
+    console.log(`  PASS: ${name}`);
+    passed++;
+  } else {
+    console.log(`  FAIL: ${name}`);
+    failed++;
+  }
+}
+
+function readJson(file) {
+  return JSON.parse(fs.readFileSync(path.join(MESSAGES_DIR, file), "utf-8"));
+}
+
+function writeJson(file, data) {
+  fs.writeFileSync(
+    path.join(MESSAGES_DIR, file),
+    JSON.stringify(data, null, 2) + "\n",
+    "utf-8"
+  );
+}
+
+function run() {
+  return execSync(`node "${SCRIPT}"`, { encoding: "utf-8" });
+}
+
+// Backup originals
+const enBackup = readJson("en.json");
+const frBackup = readJson("fr.json");
+
+try {
+  // --- Test 1: New key in en.json is propagated to all locales ---
+  console.log("Test 1: Missing key added to all locales");
+  const en = readJson("en.json");
+  en["__test_new_key"] = "Test value";
+  writeJson("en.json", en);
+
+  run();
+
+  const fr1 = readJson("fr.json");
+  const de1 = readJson("de.json");
+  assert(fr1["__test_new_key"] === "Test value", "key added to fr.json");
+  assert(de1["__test_new_key"] === "Test value", "key added to de.json");
+
+  // --- Test 2: Stale key in locale is removed ---
+  console.log("Test 2: Stale key removed from locale");
+  const fr2 = readJson("fr.json");
+  fr2["__stale_key"] = "Should be removed";
+  writeJson("fr.json", fr2);
+
+  run();
+
+  const fr3 = readJson("fr.json");
+  assert(!("__stale_key" in fr3), "stale key removed from fr.json");
+
+  // --- Test 3: Existing translations are preserved ---
+  console.log("Test 3: Existing translations preserved");
+  assert(fr3["loading"] === frBackup["loading"], "fr loading unchanged");
+
+  // --- Test 4: Key order follows en.json ---
+  console.log("Test 4: Key order follows en.json");
+  const frKeys = Object.keys(fr3).filter((k) => !k.startsWith("$"));
+  const enKeys = Object.keys(readJson("en.json")).filter((k) => !k.startsWith("$"));
+  const frOrdered = enKeys.filter((k) => frKeys.includes(k));
+  assert(
+    JSON.stringify(frKeys) === JSON.stringify(frOrdered),
+    "fr.json key order matches en.json"
+  );
+
+  // --- Test 5: Idempotent — running twice changes nothing ---
+  console.log("Test 5: Idempotent run");
+  const output = run();
+  assert(
+    output.includes("all locales are in sync"),
+    "second run reports all in sync"
+  );
+} finally {
+  // Restore originals
+  writeJson("en.json", enBackup);
+  writeJson("fr.json", frBackup);
+  // Re-run to restore all locales
+  run();
+}
+
+console.log(`\nResults: ${passed} passed, ${failed} failed`);
+process.exit(failed > 0 ? 1 : 0);


### PR DESCRIPTION
## Summary
- Add a prebuild script (`scripts/sync-translations.cjs`) that syncs missing i18n keys from `en.json` to all 19 other locale files, using the English value as fallback
- Hook it into `prebuild` and `predev` npm lifecycle scripts so it runs automatically
- Add unit tests (`sync-translations.test.cjs`) covering key propagation, stale key removal, ordering, and idempotency
- Update `CONTRIBUTING.md` with i18n instructions for contributors

Contributors now only need to add new message keys to `messages/en.json` — the sync script handles the rest.

Closes #39

## Test plan
- [x] Run `npm run test:i18n` — 6 tests pass
- [x] Add a key only in `en.json`, run `npm run prebuild`, verify it appears in all locale files
- [x] Run `npm run build` — full pipeline succeeds