### PR TITLE
fix: replace global shortcuts with window-scoped keyboard events

### DIFF
--- a/crates/keychainpgp-ui/frontend/src/App.svelte
+++ b/crates/keychainpgp-ui/frontend/src/App.svelte
@@ -5,7 +5,7 @@
   import { keyStore } from "$lib/stores/keys.svelte";
   import { clipboardStore } from "$lib/stores/clipboard.svelte";
   import { settingsStore } from "$lib/stores/settings.svelte";
-  import { registerHotkeys, unregisterHotkeys } from "$lib/hotkeys";
+  import { registerPanicHotkey, unregisterPanicHotkey } from "$lib/hotkeys";
   import { initLocale, localeStore } from "$lib/stores/locale.svelte";
   import { initPlatform, isDesktop, isMobile } from "$lib/platform";
   import { panicWipe } from "$lib/tauri";
@@ -36,6 +36,7 @@
   let initialized = $state(false);
   let mobile = $state(false);
   let unlistenTray: UnlistenFn | null = null;
+  let keydownHandler: ((e: KeyboardEvent) => void) | null = null;
 
   onMount(async () => {
     await initPlatform();
@@ -50,18 +51,25 @@
     if (isDesktop()) {
       clipboardStore.startPolling();
 
-      // Register global hotkeys (desktop only)
-      await registerHotkeys({
-        onEncrypt: () => appStore.dispatchAction("encrypt"),
-        onDecrypt: () => appStore.dispatchAction("decrypt"),
-        onSign: () => appStore.dispatchAction("sign"),
-        onVerify: () => appStore.dispatchAction("verify"),
-        onPanic: async () => {
-          if (settingsStore.settings.opsec_mode) {
-            await panicWipe();
-          }
-        },
+      // Register panic wipe as global hotkey (works even when app is in background)
+      await registerPanicHotkey(async () => {
+        if (settingsStore.settings.opsec_mode) {
+          await panicWipe();
+        }
       });
+
+      // Window-scoped keyboard shortcuts (only active when app has focus)
+      keydownHandler = (e: KeyboardEvent) => {
+        if (e.ctrlKey && e.shiftKey) {
+          switch (e.key.toUpperCase()) {
+            case "E": e.preventDefault(); appStore.dispatchAction("encrypt"); break;
+            case "D": e.preventDefault(); appStore.dispatchAction("decrypt"); break;
+            case "S": e.preventDefault(); appStore.dispatchAction("sign"); break;
+            case "V": e.preventDefault(); appStore.dispatchAction("verify"); break;
+          }
+        }
+      };
+      window.addEventListener("keydown", keydownHandler);
 
       // Listen for tray menu actions (desktop only)
       unlistenTray = await listen<string>("tray-action", (event) => {
@@ -78,8 +86,9 @@
 
   onDestroy(() => {
     if (isDesktop()) {
-      unregisterHotkeys();
+      unregisterPanicHotkey();
       unlistenTray?.();
+      if (keydownHandler) window.removeEventListener("keydown", keydownHandler);
     }
   });
 

--- a/crates/keychainpgp-ui/frontend/src/lib/hotkeys.ts
+++ b/crates/keychainpgp-ui/frontend/src/lib/hotkeys.ts
@@ -1,41 +1,24 @@
 /**
- * Global hotkey registration via tauri-plugin-global-shortcut.
+ * Hotkey management.
+ *
+ * - Panic wipe (Ctrl+Shift+P): registered as a GLOBAL shortcut via
+ *   tauri-plugin-global-shortcut so it works even when the app is in background.
+ * - Encrypt/Decrypt/Sign/Verify: handled as window-scoped keydown events
+ *   in App.svelte so they don't intercept system shortcuts.
  */
 import { register, unregisterAll } from "@tauri-apps/plugin-global-shortcut";
 
-export interface HotkeyHandlers {
-  onEncrypt: () => void;
-  onDecrypt: () => void;
-  onSign: () => void;
-  onVerify: () => void;
-  onPanic?: () => void;
-}
-
-export async function registerHotkeys(handlers: HotkeyHandlers) {
+export async function registerPanicHotkey(handler: () => void) {
   try {
-    await register("CmdOrCtrl+Shift+E", (event) => {
-      if (event.state === "Pressed") handlers.onEncrypt();
+    await register("CmdOrCtrl+Shift+P", (event) => {
+      if (event.state === "Pressed") handler();
     });
-    await register("CmdOrCtrl+Shift+D", (event) => {
-      if (event.state === "Pressed") handlers.onDecrypt();
-    });
-    await register("CmdOrCtrl+Shift+S", (event) => {
-      if (event.state === "Pressed") handlers.onSign();
-    });
-    await register("CmdOrCtrl+Shift+V", (event) => {
-      if (event.state === "Pressed") handlers.onVerify();
-    });
-    if (handlers.onPanic) {
-      await register("CmdOrCtrl+Shift+P", (event) => {
-        if (event.state === "Pressed") handlers.onPanic?.();
-      });
-    }
   } catch (e) {
-    console.warn("Failed to register global hotkeys:", e);
+    console.warn("Failed to register panic hotkey:", e);
   }
 }
 
-export async function unregisterHotkeys() {
+export async function unregisterPanicHotkey() {
   try {
     await unregisterAll();
   } catch {


### PR DESCRIPTION
## Summary
- Replace global shortcuts (Ctrl+Shift+E/D/S/V) with window-scoped keydown events so they don't intercept system shortcuts when app is in background
- Keep panic wipe (Ctrl+Shift+P) as global shortcut for OPSEC emergency use
- Fixes Linux terminal paste interception (Ctrl+Shift+V)

Closes #41

## Test plan
- [x] `npm run build` — frontend builds successfully
- [x] `cargo test --workspace` — all tests pass
- [x] Keyboard shortcuts (E/D/S/V) work when app window is focused
- [x] Shortcuts do NOT fire when app is in background
- [x] Panic wipe (Ctrl+Shift+P) still works globally in OPSEC mode