### PR TITLE
fix(i18n): add missing translations across all 20 locales

### DIFF
--- a/crates/keychainpgp-ui/frontend/messages/ar.json
+++ b/crates/keychainpgp-ui/frontend/messages/ar.json
@@ -266,5 +266,14 @@
   "date_na": "غير متاح",
   "fingerprint_copy": "نسخ البصمة",
   "kbd_ctrl": "Ctrl",
-  "kbd_shift": "Shift"
+  "kbd_shift": "Shift",
+  "settings_locale_auto": "تلقائي",
+  "settings_opsec_title_placeholder": "ملاحظات",
+  "sync_copy_btn": "نسخ",
+  "sync_pause": "إيقاف مؤقت",
+  "sync_play": "تشغيل",
+  "qr_code_alt": "رمز QR",
+  "error_sync_qr_wrong_context": "هذا رمز QR للمزامنة. استخدم الإعدادات → مزامنة المفاتيح → استيراد المفاتيح.",
+  "error_sync_qr_use_sync": "هذا رمز QR للمزامنة. استخدم وظيفة المزامنة بدلاً من ذلك.",
+  "error_not_sync_qr": "ليس رمز QR للمزامنة. استخدم وظيفة استيراد المفتاح للمفاتيح الفردية."
 }

--- a/crates/keychainpgp-ui/frontend/messages/de.json
+++ b/crates/keychainpgp-ui/frontend/messages/de.json
@@ -266,5 +266,14 @@
   "date_na": "k. A.",
   "fingerprint_copy": "Fingerabdruck kopieren",
   "kbd_ctrl": "Strg",
-  "kbd_shift": "Umschalt"
+  "kbd_shift": "Umschalt",
+  "settings_locale_auto": "Automatisch",
+  "settings_opsec_title_placeholder": "Notizen",
+  "sync_copy_btn": "Kopieren",
+  "sync_pause": "Pause",
+  "sync_play": "Abspielen",
+  "qr_code_alt": "QR-Code",
+  "error_sync_qr_wrong_context": "Dies ist ein Sync-QR-Code. Verwende Einstellungen → Schlüssel-Synchronisation → Schlüssel importieren.",
+  "error_sync_qr_use_sync": "Dies ist ein Sync-QR-Code. Verwende stattdessen die Sync-Funktion.",
+  "error_not_sync_qr": "Kein Sync-QR-Code. Verwende die Schlüssel-Import-Funktion für einzelne Schlüssel."
 }

--- a/crates/keychainpgp-ui/frontend/messages/en.json
+++ b/crates/keychainpgp-ui/frontend/messages/en.json
@@ -266,5 +266,14 @@
   "date_na": "N/A",
   "fingerprint_copy": "Copy fingerprint",
   "kbd_ctrl": "Ctrl",
-  "kbd_shift": "Shift"
+  "kbd_shift": "Shift",
+  "settings_locale_auto": "Auto",
+  "settings_opsec_title_placeholder": "Notes",
+  "sync_copy_btn": "Copy",
+  "sync_pause": "Pause",
+  "sync_play": "Play",
+  "qr_code_alt": "QR Code",
+  "error_sync_qr_wrong_context": "This is a sync QR code. Use Settings → Key Sync → Import Keys.",
+  "error_sync_qr_use_sync": "This is a sync QR code. Use the Sync function instead.",
+  "error_not_sync_qr": "Not a sync QR code. Use the Import Key function for single keys."
 }

--- a/crates/keychainpgp-ui/frontend/messages/es.json
+++ b/crates/keychainpgp-ui/frontend/messages/es.json
@@ -266,5 +266,14 @@
   "date_na": "N/D",
   "fingerprint_copy": "Copiar huella digital",
   "kbd_ctrl": "Ctrl",
-  "kbd_shift": "Mayús"
+  "kbd_shift": "Mayús",
+  "settings_locale_auto": "Automático",
+  "settings_opsec_title_placeholder": "Notas",
+  "sync_copy_btn": "Copiar",
+  "sync_pause": "Pausar",
+  "sync_play": "Reproducir",
+  "qr_code_alt": "Código QR",
+  "error_sync_qr_wrong_context": "Este es un código QR de sincronización. Usa Ajustes → Sincronización de claves → Importar claves.",
+  "error_sync_qr_use_sync": "Este es un código QR de sincronización. Usa la función de sincronización en su lugar.",
+  "error_not_sync_qr": "Este no es un código QR de sincronización. Usa la función de importar clave para claves individuales."
 }

--- a/crates/keychainpgp-ui/frontend/messages/fr.json
+++ b/crates/keychainpgp-ui/frontend/messages/fr.json
@@ -266,5 +266,14 @@
   "date_na": "N/D",
   "fingerprint_copy": "Copier l'empreinte",
   "kbd_ctrl": "Ctrl",
-  "kbd_shift": "Maj"
+  "kbd_shift": "Maj",
+  "settings_locale_auto": "Automatique",
+  "settings_opsec_title_placeholder": "Notes",
+  "sync_copy_btn": "Copier",
+  "sync_pause": "Pause",
+  "sync_play": "Lecture",
+  "qr_code_alt": "Code QR",
+  "error_sync_qr_wrong_context": "Ceci est un QR code de synchronisation. Utilisez Paramètres → Synchronisation des clés → Importer des clés.",
+  "error_sync_qr_use_sync": "Ceci est un QR code de synchronisation. Utilisez la fonction Sync à la place.",
+  "error_not_sync_qr": "Ce n'est pas un QR code de synchronisation. Utilisez la fonction Importer une clé pour les clés individuelles."
 }

--- a/crates/keychainpgp-ui/frontend/messages/he.json
+++ b/crates/keychainpgp-ui/frontend/messages/he.json
@@ -266,5 +266,14 @@
   "date_na": "לא זמין",
   "fingerprint_copy": "העתק טביעת אצבע",
   "kbd_ctrl": "Ctrl",
-  "kbd_shift": "Shift"
+  "kbd_shift": "Shift",
+  "settings_locale_auto": "אוטומטי",
+  "settings_opsec_title_placeholder": "פתקים",
+  "sync_copy_btn": "העתק",
+  "sync_pause": "השהה",
+  "sync_play": "הפעל",
+  "qr_code_alt": "קוד QR",
+  "error_sync_qr_wrong_context": "זהו קוד QR לסנכרון. השתמש בהגדרות → סנכרון מפתחות → ייבא מפתחות.",
+  "error_sync_qr_use_sync": "זהו קוד QR לסנכרון. השתמש בפונקציית הסנכרון במקום.",
+  "error_not_sync_qr": "זה לא קוד QR לסנכרון. השתמש בפונקציית ייבוא מפתח למפתחות בודדים."
 }

--- a/crates/keychainpgp-ui/frontend/messages/hi.json
+++ b/crates/keychainpgp-ui/frontend/messages/hi.json
@@ -266,5 +266,14 @@
   "date_na": "उपलब्ध नहीं",
   "fingerprint_copy": "फ़िंगरप्रिंट कॉपी करें",
   "kbd_ctrl": "Ctrl",
-  "kbd_shift": "Shift"
+  "kbd_shift": "Shift",
+  "settings_locale_auto": "स्वचालित",
+  "settings_opsec_title_placeholder": "नोट्स",
+  "sync_copy_btn": "कॉपी करें",
+  "sync_pause": "रोकें",
+  "sync_play": "चलाएं",
+  "qr_code_alt": "QR कोड",
+  "error_sync_qr_wrong_context": "यह एक सिंक QR कोड है। सेटिंग्स → कुंजी सिंक → कुंजियाँ आयात करें का उपयोग करें।",
+  "error_sync_qr_use_sync": "यह एक सिंक QR कोड है। इसके बजाय सिंक फ़ंक्शन का उपयोग करें।",
+  "error_not_sync_qr": "यह सिंक QR कोड नहीं है। एकल कुंजियों के लिए कुंजी आयात फ़ंक्शन का उपयोग करें।"
 }

--- a/crates/keychainpgp-ui/frontend/messages/it.json
+++ b/crates/keychainpgp-ui/frontend/messages/it.json
@@ -266,5 +266,14 @@
   "date_na": "N/D",
   "fingerprint_copy": "Copia impronta digitale",
   "kbd_ctrl": "Ctrl",
-  "kbd_shift": "Maiusc"
+  "kbd_shift": "Maiusc",
+  "settings_locale_auto": "Automatico",
+  "settings_opsec_title_placeholder": "Note",
+  "sync_copy_btn": "Copia",
+  "sync_pause": "Pausa",
+  "sync_play": "Riproduci",
+  "qr_code_alt": "Codice QR",
+  "error_sync_qr_wrong_context": "Questo è un codice QR di sincronizzazione. Usa Impostazioni → Sincronizzazione chiavi → Importa chiavi.",
+  "error_sync_qr_use_sync": "Questo è un codice QR di sincronizzazione. Usa invece la funzione Sincronizza.",
+  "error_not_sync_qr": "Non è un codice QR di sincronizzazione. Usa la funzione Importa chiave per le chiavi singole."
 }

--- a/crates/keychainpgp-ui/frontend/messages/ja.json
+++ b/crates/keychainpgp-ui/frontend/messages/ja.json
@@ -266,5 +266,14 @@
   "date_na": "N/A",
   "fingerprint_copy": "フィンガープリントをコピー",
   "kbd_ctrl": "Ctrl",
-  "kbd_shift": "Shift"
+  "kbd_shift": "Shift",
+  "settings_locale_auto": "自動",
+  "settings_opsec_title_placeholder": "メモ",
+  "sync_copy_btn": "コピー",
+  "sync_pause": "一時停止",
+  "sync_play": "再生",
+  "qr_code_alt": "QRコード",
+  "error_sync_qr_wrong_context": "これは同期用QRコードです。設定 → 鍵の同期 → 鍵をインポートを使用してください。",
+  "error_sync_qr_use_sync": "これは同期用QRコードです。代わりに同期機能を使用してください。",
+  "error_not_sync_qr": "これは同期用QRコードではありません。個別の鍵には鍵のインポート機能を使用してください。"
 }

--- a/crates/keychainpgp-ui/frontend/messages/ko.json
+++ b/crates/keychainpgp-ui/frontend/messages/ko.json
@@ -266,5 +266,14 @@
   "date_na": "해당 없음",
   "fingerprint_copy": "지문 복사",
   "kbd_ctrl": "Ctrl",
-  "kbd_shift": "Shift"
+  "kbd_shift": "Shift",
+  "settings_locale_auto": "자동",
+  "settings_opsec_title_placeholder": "메모",
+  "sync_copy_btn": "복사",
+  "sync_pause": "일시정지",
+  "sync_play": "재생",
+  "qr_code_alt": "QR 코드",
+  "error_sync_qr_wrong_context": "동기화 QR 코드입니다. 설정 → 키 동기화 → 키 가져오기를 사용하세요.",
+  "error_sync_qr_use_sync": "동기화 QR 코드입니다. 대신 동기화 기능을 사용하세요.",
+  "error_not_sync_qr": "동기화 QR 코드가 아닙니다. 단일 키에는 키 가져오기 기능을 사용하세요."
 }

--- a/crates/keychainpgp-ui/frontend/messages/nl.json
+++ b/crates/keychainpgp-ui/frontend/messages/nl.json
@@ -266,5 +266,14 @@
   "date_na": "N.v.t.",
   "fingerprint_copy": "Vingerafdruk kopiëren",
   "kbd_ctrl": "Ctrl",
-  "kbd_shift": "Shift"
+  "kbd_shift": "Shift",
+  "settings_locale_auto": "Automatisch",
+  "settings_opsec_title_placeholder": "Notities",
+  "sync_copy_btn": "Kopiëren",
+  "sync_pause": "Pauzeren",
+  "sync_play": "Afspelen",
+  "qr_code_alt": "QR-code",
+  "error_sync_qr_wrong_context": "Dit is een synchronisatie-QR-code. Gebruik Instellingen → Sleutelsynchronisatie → Sleutels importeren.",
+  "error_sync_qr_use_sync": "Dit is een synchronisatie-QR-code. Gebruik in plaats daarvan de synchronisatiefunctie.",
+  "error_not_sync_qr": "Geen synchronisatie-QR-code. Gebruik de sleutelimportfunctie voor afzonderlijke sleutels."
 }

--- a/crates/keychainpgp-ui/frontend/messages/pl.json
+++ b/crates/keychainpgp-ui/frontend/messages/pl.json
@@ -266,5 +266,14 @@
   "date_na": "N/D",
   "fingerprint_copy": "Kopiuj odcisk",
   "kbd_ctrl": "Ctrl",
-  "kbd_shift": "Shift"
+  "kbd_shift": "Shift",
+  "settings_locale_auto": "Automatycznie",
+  "settings_opsec_title_placeholder": "Notatki",
+  "sync_copy_btn": "Kopiuj",
+  "sync_pause": "Wstrzymaj",
+  "sync_play": "Odtwórz",
+  "qr_code_alt": "Kod QR",
+  "error_sync_qr_wrong_context": "To jest kod QR synchronizacji. Użyj Ustawienia → Synchronizacja kluczy → Importuj klucze.",
+  "error_sync_qr_use_sync": "To jest kod QR synchronizacji. Zamiast tego użyj funkcji synchronizacji.",
+  "error_not_sync_qr": "To nie jest kod QR synchronizacji. Użyj funkcji importu klucza dla pojedynczych kluczy."
 }

--- a/crates/keychainpgp-ui/frontend/messages/pt-BR.json
+++ b/crates/keychainpgp-ui/frontend/messages/pt-BR.json
@@ -266,5 +266,14 @@
   "date_na": "N/D",
   "fingerprint_copy": "Copiar impressão digital",
   "kbd_ctrl": "Ctrl",
-  "kbd_shift": "Shift"
+  "kbd_shift": "Shift",
+  "settings_locale_auto": "Automático",
+  "settings_opsec_title_placeholder": "Notas",
+  "sync_copy_btn": "Copiar",
+  "sync_pause": "Pausar",
+  "sync_play": "Reproduzir",
+  "qr_code_alt": "Código QR",
+  "error_sync_qr_wrong_context": "Este é um QR code de sincronização. Use Configurações → Sincronização de chaves → Importar chaves.",
+  "error_sync_qr_use_sync": "Este é um QR code de sincronização. Use a função de sincronização.",
+  "error_not_sync_qr": "Este não é um QR code de sincronização. Use a função de importar chave para chaves individuais."
 }

--- a/crates/keychainpgp-ui/frontend/messages/pt-PT.json
+++ b/crates/keychainpgp-ui/frontend/messages/pt-PT.json
@@ -266,5 +266,14 @@
   "date_na": "N/D",
   "fingerprint_copy": "Copiar impressão digital",
   "kbd_ctrl": "Ctrl",
-  "kbd_shift": "Shift"
+  "kbd_shift": "Shift",
+  "settings_locale_auto": "Automático",
+  "settings_opsec_title_placeholder": "Notas",
+  "sync_copy_btn": "Copiar",
+  "sync_pause": "Pausar",
+  "sync_play": "Reproduzir",
+  "qr_code_alt": "Código QR",
+  "error_sync_qr_wrong_context": "Este é um código QR de sincronização. Utilize Definições → Sincronização de chaves → Importar chaves.",
+  "error_sync_qr_use_sync": "Este é um código QR de sincronização. Utilize a função de sincronização.",
+  "error_not_sync_qr": "Este não é um código QR de sincronização. Utilize a função de importar chave para chaves individuais."
 }

--- a/crates/keychainpgp-ui/frontend/messages/ru.json
+++ b/crates/keychainpgp-ui/frontend/messages/ru.json
@@ -266,5 +266,14 @@
   "date_na": "Н/Д",
   "fingerprint_copy": "Копировать отпечаток",
   "kbd_ctrl": "Ctrl",
-  "kbd_shift": "Shift"
+  "kbd_shift": "Shift",
+  "settings_locale_auto": "Авто",
+  "settings_opsec_title_placeholder": "Заметки",
+  "sync_copy_btn": "Копировать",
+  "sync_pause": "Пауза",
+  "sync_play": "Воспроизвести",
+  "qr_code_alt": "QR-код",
+  "error_sync_qr_wrong_context": "Это QR-код синхронизации. Используйте Настройки → Синхронизация ключей → Импортировать ключи.",
+  "error_sync_qr_use_sync": "Это QR-код синхронизации. Вместо этого используйте функцию синхронизации.",
+  "error_not_sync_qr": "Это не QR-код синхронизации. Используйте функцию импорта ключа для отдельных ключей."
 }

--- a/crates/keychainpgp-ui/frontend/messages/th.json
+++ b/crates/keychainpgp-ui/frontend/messages/th.json
@@ -266,5 +266,14 @@
   "date_na": "ไม่มีข้อมูล",
   "fingerprint_copy": "คัดลอกลายนิ้วมือ",
   "kbd_ctrl": "Ctrl",
-  "kbd_shift": "Shift"
+  "kbd_shift": "Shift",
+  "settings_locale_auto": "อัตโนมัติ",
+  "settings_opsec_title_placeholder": "บันทึก",
+  "sync_copy_btn": "คัดลอก",
+  "sync_pause": "หยุดชั่วคราว",
+  "sync_play": "เล่น",
+  "qr_code_alt": "QR โค้ด",
+  "error_sync_qr_wrong_context": "นี่คือ QR code สำหรับซิงค์ ใช้ การตั้งค่า → ซิงค์คีย์ → นำเข้าคีย์",
+  "error_sync_qr_use_sync": "นี่คือ QR code สำหรับซิงค์ ใช้ฟังก์ชันซิงค์แทน",
+  "error_not_sync_qr": "ไม่ใช่ QR code สำหรับซิงค์ ใช้ฟังก์ชันนำเข้าคีย์สำหรับคีย์แต่ละรายการ"
 }

--- a/crates/keychainpgp-ui/frontend/messages/tr.json
+++ b/crates/keychainpgp-ui/frontend/messages/tr.json
@@ -266,5 +266,14 @@
   "date_na": "Yok",
   "fingerprint_copy": "Parmak izini kopyala",
   "kbd_ctrl": "Ctrl",
-  "kbd_shift": "Shift"
+  "kbd_shift": "Shift",
+  "settings_locale_auto": "Otomatik",
+  "settings_opsec_title_placeholder": "Notlar",
+  "sync_copy_btn": "Kopyala",
+  "sync_pause": "Duraklat",
+  "sync_play": "Oynat",
+  "qr_code_alt": "QR Kodu",
+  "error_sync_qr_wrong_context": "Bu bir senkronizasyon QR kodudur. Ayarlar → Anahtar Senkronizasyonu → Anahtarları İçe Aktar'ı kullanın.",
+  "error_sync_qr_use_sync": "Bu bir senkronizasyon QR kodudur. Bunun yerine Senkronizasyon işlevini kullanın.",
+  "error_not_sync_qr": "Bu bir senkronizasyon QR kodu değildir. Tek anahtarlar için Anahtar İçe Aktar işlevini kullanın."
 }

--- a/crates/keychainpgp-ui/frontend/messages/uk.json
+++ b/crates/keychainpgp-ui/frontend/messages/uk.json
@@ -266,5 +266,14 @@
   "date_na": "Н/Д",
   "fingerprint_copy": "Копіювати відбиток",
   "kbd_ctrl": "Ctrl",
-  "kbd_shift": "Shift"
+  "kbd_shift": "Shift",
+  "settings_locale_auto": "Авто",
+  "settings_opsec_title_placeholder": "Нотатки",
+  "sync_copy_btn": "Копіювати",
+  "sync_pause": "Пауза",
+  "sync_play": "Відтворити",
+  "qr_code_alt": "QR-код",
+  "error_sync_qr_wrong_context": "Це QR-код синхронізації. Використовуйте Налаштування → Синхронізація ключів → Імпортувати ключі.",
+  "error_sync_qr_use_sync": "Це QR-код синхронізації. Натомість використовуйте функцію синхронізації.",
+  "error_not_sync_qr": "Це не QR-код синхронізації. Використовуйте функцію імпорту ключа для окремих ключів."
 }

--- a/crates/keychainpgp-ui/frontend/messages/zh-CN.json
+++ b/crates/keychainpgp-ui/frontend/messages/zh-CN.json
@@ -266,5 +266,14 @@
   "date_na": "不适用",
   "fingerprint_copy": "复制指纹",
   "kbd_ctrl": "Ctrl",
-  "kbd_shift": "Shift"
+  "kbd_shift": "Shift",
+  "settings_locale_auto": "自动",
+  "settings_opsec_title_placeholder": "便签",
+  "sync_copy_btn": "复制",
+  "sync_pause": "暂停",
+  "sync_play": "播放",
+  "qr_code_alt": "二维码",
+  "error_sync_qr_wrong_context": "这是同步二维码，请使用设置 → 密钥同步 → 导入密钥。",
+  "error_sync_qr_use_sync": "这是同步二维码，请改用同步功能。",
+  "error_not_sync_qr": "这不是同步二维码，请使用导入密钥功能导入单个密钥。"
 }

--- a/crates/keychainpgp-ui/frontend/messages/zh-TW.json
+++ b/crates/keychainpgp-ui/frontend/messages/zh-TW.json
@@ -266,5 +266,14 @@
   "date_na": "不適用",
   "fingerprint_copy": "複製指紋",
   "kbd_ctrl": "Ctrl",
-  "kbd_shift": "Shift"
+  "kbd_shift": "Shift",
+  "settings_locale_auto": "自動",
+  "settings_opsec_title_placeholder": "備忘錄",
+  "sync_copy_btn": "複製",
+  "sync_pause": "暫停",
+  "sync_play": "播放",
+  "qr_code_alt": "QR碼",
+  "error_sync_qr_wrong_context": "這是同步QR碼，請使用設定 → 金鑰同步 → 匯入金鑰。",
+  "error_sync_qr_use_sync": "這是同步QR碼，請改用同步功能。",
+  "error_not_sync_qr": "這不是同步QR碼，請使用匯入金鑰功能匯入個別金鑰。"
 }

--- a/crates/keychainpgp-ui/frontend/src/components/keys/KeysView.svelte
+++ b/crates/keychainpgp-ui/frontend/src/components/keys/KeysView.svelte
@@ -40,7 +40,7 @@
 
   function handleScanResult(content: string): boolean {
     if (content.startsWith("KCPGP:")) {
-      appStore.setStatus("This is a sync QR code. Use Settings → Key Sync → Import Keys.");
+      appStore.setStatus(m.error_sync_qr_wrong_context());
       return true;
     }
     importKey(content)

--- a/crates/keychainpgp-ui/frontend/src/components/modals/DonateModal.svelte
+++ b/crates/keychainpgp-ui/frontend/src/components/modals/DonateModal.svelte
@@ -97,7 +97,7 @@
 
         {#if qrSvgs[wallet.id]}
           <div class="flex justify-center rounded-lg bg-white p-3">
-            <img src="data:image/svg+xml;base64,{btoa(qrSvgs[wallet.id])}" alt="QR Code" />
+            <img src="data:image/svg+xml;base64,{btoa(qrSvgs[wallet.id])}" alt={m.qr_code_alt()} />
           </div>
         {:else}
           <p class="text-center text-xs text-[var(--color-text-secondary)]">

--- a/crates/keychainpgp-ui/frontend/src/components/modals/KeyImportDialog.svelte
+++ b/crates/keychainpgp-ui/frontend/src/components/modals/KeyImportDialog.svelte
@@ -88,7 +88,7 @@
   <QrScanOverlay
     onscan={(content) => {
       if (content.startsWith("KCPGP:")) {
-        error = "This is a sync QR code. Use Settings → Key Sync → Import Keys.";
+        error = m.error_sync_qr_wrong_context();
         scanning = false;
         return true;
       }

--- a/crates/keychainpgp-ui/frontend/src/components/modals/KeySyncExportModal.svelte
+++ b/crates/keychainpgp-ui/frontend/src/components/modals/KeySyncExportModal.svelte
@@ -118,7 +118,7 @@
           <button
             class="rounded p-1.5 transition-colors hover:bg-[var(--color-border)]"
             onclick={copyPassphrase}
-            title="Copy"
+            title={m.sync_copy_btn()}
           >
             <Copy size={16} />
           </button>
@@ -139,7 +139,7 @@
           >
             <img
               src="data:image/svg+xml;base64,{btoa(bundle.qr_parts[currentQrIndex])}"
-              alt="QR Code"
+              alt={m.qr_code_alt()}
             />
           </div>
           {#if bundle.qr_parts.length > 1}
@@ -156,7 +156,7 @@
               <button
                 class="rounded p-1.5 transition-colors hover:bg-[var(--color-bg-secondary)]"
                 onclick={toggleAutoPlay}
-                title={autoPlay ? "Pause" : "Play"}
+                title={autoPlay ? m.sync_pause() : m.sync_play()}
               >
                 {#if autoPlay}
                   <Pause size={18} />

--- a/crates/keychainpgp-ui/frontend/src/components/modals/KeySyncImportModal.svelte
+++ b/crates/keychainpgp-ui/frontend/src/components/modals/KeySyncImportModal.svelte
@@ -40,7 +40,7 @@
 
     const part = parseKcpgpPart(content);
     if (!part) {
-      error = "Not a sync QR code. Use the Import Key function for single keys.";
+      error = m.error_not_sync_qr();
       return true; // stop
     }
 

--- a/crates/keychainpgp-ui/frontend/src/components/modals/QrExportModal.svelte
+++ b/crates/keychainpgp-ui/frontend/src/components/modals/QrExportModal.svelte
@@ -28,7 +28,7 @@
       <p class="text-sm text-red-600">{error}</p>
     {:else if svgData}
       <div class="flex justify-center rounded-lg bg-white p-4">
-        <img src="data:image/svg+xml;base64,{btoa(svgData)}" alt="QR Code" />
+        <img src="data:image/svg+xml;base64,{btoa(svgData)}" alt={m.qr_code_alt()} />
       </div>
       <p class="text-center text-xs text-[var(--color-text-secondary)]">
         {m.qr_desc()}

--- a/crates/keychainpgp-ui/frontend/src/components/onboarding/OnboardingView.svelte
+++ b/crates/keychainpgp-ui/frontend/src/components/onboarding/OnboardingView.svelte
@@ -37,7 +37,7 @@
 
   function handleScanResult(content: string): boolean {
     if (content.startsWith("KCPGP:")) {
-      error = "This is a sync QR code. Use the Sync function instead.";
+      error = m.error_sync_qr_use_sync();
       return true;
     }
     importKey(content)

--- a/crates/keychainpgp-ui/frontend/src/components/settings/SettingsView.svelte
+++ b/crates/keychainpgp-ui/frontend/src/components/settings/SettingsView.svelte
@@ -231,7 +231,7 @@
         class="rounded border border-[var(--color-border)] bg-[var(--color-bg)] px-2 py-1 text-sm
                focus:ring-2 focus:ring-[var(--color-primary)] focus:outline-none"
       >
-        <option value="auto">Auto</option>
+        <option value="auto">{m.settings_locale_auto()}</option>
         {#each localeStore.locales as loc}
           <option value={loc}>{LOCALE_LABELS[loc] ?? loc}</option>
         {/each}
@@ -437,8 +437,10 @@
             type="text"
             value={settingsStore.settings.opsec_window_title}
             onchange={(e) =>
-              settingsStore.save({ opsec_window_title: e.currentTarget.value || "Notes" })}
-            placeholder="Notes"
+              settingsStore.save({
+                opsec_window_title: e.currentTarget.value || m.settings_opsec_title_placeholder(),
+              })}
+            placeholder={m.settings_opsec_title_placeholder()}
             class="w-32 rounded border border-[var(--color-border)] bg-[var(--color-bg)] px-2 py-1 text-sm
                  focus:ring-2 focus:ring-[var(--color-primary)] focus:outline-none"
           />

--- a/crates/keychainpgp-ui/frontend/src/lib/qr-scan.ts
+++ b/crates/keychainpgp-ui/frontend/src/lib/qr-scan.ts
@@ -7,6 +7,7 @@
  */
 import QrScanner from "qr-scanner";
 import { importKey, type KeyInfo } from "$lib/tauri";
+import * as m from "$lib/paraglide/messages.js";
 
 /** Active scanner instance (singleton — only one scan session at a time). */
 let activeScanner: QrScanner | null = null;
@@ -77,9 +78,7 @@ export function cancelScan(): void {
  */
 export async function importScannedContent(content: string): Promise<KeyInfo> {
   if (content.startsWith("KCPGP:")) {
-    throw new Error(
-      "This is a sync QR code. Use Settings → Key Sync → Import Keys to scan sync codes.",
-    );
+    throw new Error(m.error_sync_qr_wrong_context());
   }
   return await importKey(content);
 }


### PR DESCRIPTION
## Summary

- Added missing translation keys across all 20 locales (277 keys each)
- Updated Svelte components and `qr-scan.ts` to use i18n message functions
- Verified no fallbacks: every locale has 100% key coverage

## Test plan

- [x] Build the frontend and verify no missing translation warnings
- [x] Spot-check a few locales in the UI (e.g. fr, de, ja, ar)
- [x] Confirm QR scan, key sync, donate, and onboarding screens display translated strings